### PR TITLE
Pass locale args through `run` builders/runners

### DIFF
--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -1,27 +1,29 @@
 const path = require('path');
 const chalk = require('chalk');
-const packageConfig = require('../util/packageConfig');
 
+const addLocalesOption = require('../util/addLocalesOption');
+const packageConfig = require('../util/packageConfig');
 const startDev = require('./runScripts/start-dev');
 
 module.exports = {
 	command: 'run',
 	description: 'run the application server',
+	builder: yargs => addLocalesOption(yargs),
 	handler: argv => {
 		const { NODE_ENV } = process.env;
 		const envString = NODE_ENV || 'development';
-		console.log(
-			chalk.green(`NODE_ENV=${envString}`)
-		);
+		console.log(chalk.green(`NODE_ENV=${envString}`));
 		if (envString !== 'development') {
-			console.log(chalk.red(`Cannot run dev server with NODE_ENV=${envString}`))
-			console.log(chalk.red(`Set NODE_ENV=development`))
+			console.log(
+				chalk.red(`Cannot run dev server with NODE_ENV=${envString}`)
+			);
+			console.log(chalk.red(`Set NODE_ENV=development`));
 			process.exit(1);
 		}
 		// TODO: check for prerequisites (e.g. up-to-date build/... files)
 		// execute the start-dev script
 		console.log(chalk.blue('Preparing the dev app server...'));
-		startDev(packageConfig);
+		startDev(packageConfig, argv.locales);
 		return;
 	},
 };

--- a/src/commands/runScripts/start-dev.js
+++ b/src/commands/runScripts/start-dev.js
@@ -31,7 +31,7 @@ function getSubdomain(packageConfig) {
 	const { subdomain } = packageConfig;
 	if (!subdomain) {
 		throw new Error(
-			chalk.red('You must supply packageConfig.subdomain in package.json')
+			chalk.red('You must supply config.subdomain in package.json')
 		);
 	}
 	return subdomain;


### PR DESCRIPTION
the locale args weren't being passed to `startServer` in `start-dev.js`. This PR fixes that.

When mup-web and pro-web are updated, `yarn start -- --locales en-US fr-FR` will run the server with multiple language support