### PR TITLE
Proper source maps in dev

### DIFF
--- a/src/commands/buildCommands/config/webpack/browserAppConfig.js
+++ b/src/commands/buildCommands/config/webpack/browserAppConfig.js
@@ -57,10 +57,7 @@ function getConfig(localeCode) {
 			publicPath: `/static/${localeCode}/`,
 		},
 
-		// source maps are slow to generate, so only create them in prod
-		// also, the `eval` output provides sufficient source map hooks
-		// this needs revision: https://meetup.atlassian.net/browse/MW-952
-		devtool: env.properties.isDev ? 'eval' : 'source-map',
+		devtool: 'cheap-module-source-map', // similar speed to 'eval', but with proper source maps
 
 		module: {
 			rules: [

--- a/src/commands/buildCommands/config/webpack/serverAppConfig.js
+++ b/src/commands/buildCommands/config/webpack/serverAppConfig.js
@@ -35,8 +35,6 @@ function getConfig(localeCode) {
 			publicPath,
 		},
 
-		devtool: 'eval',
-
 		module: {
 			rules: [
 				{

--- a/src/commands/buildCommands/config/webpack/serverAppConfig.js
+++ b/src/commands/buildCommands/config/webpack/serverAppConfig.js
@@ -35,6 +35,8 @@ function getConfig(localeCode) {
 			publicPath,
 		},
 
+		devtool: 'eval',
+
 		module: {
 			rules: [
 				{


### PR DESCRIPTION
`eval` was providing a source map that contained the transpiled code

`cheap-module-source-map` creates a source map that shows the original code, and it appears to be approximately as fast as `eval` - in mup-web `yarn start` takes about 10 seconds with `eval`, and 11 seconds with `cheap-module-source-map`.

I've also removed the `devtool` config for `serverAppMap` because we don't have a use case server app source maps currently, and it makes the server build slightly slower than having no `devtool` at all.

Before:
![screen shot 2017-07-13 at 11 57 03 am](https://user-images.githubusercontent.com/1885153/28145469-a81dd94e-67c6-11e7-9a12-7122eef5451e.png)

After:
![screen shot 2017-07-13 at 11 56 19 am](https://user-images.githubusercontent.com/1885153/28145474-acabe5aa-67c6-11e7-9527-ecf1b32f401d.png)
