### PR TITLE
WP 454 Webpack Dev Server asset server logging

### DIFF
--- a/docs/run.md
+++ b/docs/run.md
@@ -1,7 +1,16 @@
-### Run: `mope run`
+## Run: `mope run`
 
 _Only available in development._
 
 This command spawns separate processes for the asset server (Webpack Dev Server)
 and app server (Node - Hapi), and watches the consumer repo for code changes
 that will hot-reload and restart the server as needed during development.
+
+### Options
+
+#### `--log-static`
+
+Enable request logging for the Webpack Dev Server. This can be useful to see
+what static asset requests are made be the app and how they are handled by WDS.
+This logging is disabled by default because the logs are a little noisy and
+interleaved with app server logs.

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -7,7 +7,7 @@ const startDev = require('./runScripts/start-dev');
 module.exports = {
 	command: 'run',
 	description: 'run the application server',
-	builder: yargs => addLocalesOption(yargs),
+	builder: yargs => addLocalesOption(yargs).option('log-static'),
 	handler: argv => {
 		const { NODE_ENV } = process.env;
 		const envString = NODE_ENV || 'development';
@@ -18,6 +18,9 @@ module.exports = {
 			);
 			console.log(chalk.red(`Set NODE_ENV=development`));
 			process.exit(1);
+		}
+		if (argv['log-static']) {
+			process.env.DEBUG = 'express:router';
 		}
 		// TODO: check for prerequisites (e.g. up-to-date build/... files)
 		// execute the start-dev script


### PR DESCRIPTION
Enabling request logging in WDS is a little indirect because you have to set an environment variable that the Express server reads to determine whether/what to log. I decided that enabling this logging with a CLI option was probably the best opt-in mechanism, and the code change is pretty minor. Not sure if we should use another channel to let people know that this option exists - I suspect it will mostly go unnoticed.