### PR TITLE
WP 425 config docs + server config consolidation

### DIFF
--- a/src/config/README.md
+++ b/src/config/README.md
@@ -10,6 +10,10 @@ By consolidating all of this configuration into a single module/package, all
 downstream dependencies can explicitly opt-in to reading configuration values
 that determine the behavior of the system.
 
+**Important**: browser-run scripts should never directly import configuration 
+values. Instead, config should be read from the application state provided to 
+the client on initial render.
+
 ## General config
 
 The root-level modules of the config package each organize some information that
@@ -22,7 +26,13 @@ config values.
 Build-time config is primarily used by Webpack and its dependencies to define
 build behavior, including paths to the source files and build targets.
 
-All **Babel** plugins and presets are defined in the `src/babel` module.
+All **Babel** plugins and presets are defined in the `/babel` module.
 
-All **Webpack** configuration rules and helpers are defined in the `src/webpack`
+All **Webpack** configuration rules and helpers are defined in the `/webpack`
 module.
+
+## Server config
+
+The `/server` module defines the runtime configuration of the Node application
+server. It is essentially an extension of the `/env` config, but adds a few more
+host and authentication configuration values.

--- a/src/config/README.md
+++ b/src/config/README.md
@@ -1,0 +1,28 @@
+# Config
+
+This is the 'master' config for all Meetup Web Platform applications. It is
+intended to consolidate both buildtime and runtime configuration properties and
+rules, including Babel and Webpack configuration, Node server config, and
+configuration needed to to interface with external services such as Travis CI
+and Transifex.
+
+By consolidating all of this configuration into a single module/package, all
+downstream dependencies can explicitly opt-in to reading configuration values
+that determine the behavior of the system.
+
+## General config
+
+The root-level modules of the config package each organize some information that
+is used by many different packages. For the most part, they describe the
+application environment, e.g. standard file `paths`, `env` values, and `package`
+config values.
+
+## Build config
+
+Build-time config is primarily used by Webpack and its dependencies to define
+build behavior, including paths to the source files and build targets.
+
+All **Babel** plugins and presets are defined in the `src/babel` module.
+
+All **Webpack** configuration rules and helpers are defined in the `src/webpack`
+module.

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -5,4 +5,5 @@ module.exports = {
 	package: require('./package'),
 	paths: require('./paths'),
 	webpack: require('./webpack'),
+	server: require('./server'),
 };

--- a/src/config/server/index.js
+++ b/src/config/server/index.js
@@ -121,20 +121,20 @@ const schema = Object.assign({}, envSchema, {
 		},
 		secret: {
 			format: validateOauthSecret,
-			default: null,
+			default: process.env.NODE_ENV === 'test' ? secretDefault : null,
 			env: 'MUPWEB_OAUTH_SECRET',
 			sensitive: true,
 		},
 		key: {
 			format: validateOauthKey,
-			default: null,
+			default: process.env.NODE_ENV === 'test' ? secretDefault : null,
 			env: 'MUPWEB_OAUTH_KEY',
 			sensitive: true,
 		},
 	},
 	photo_scaler_salt: {
 		format: validatePhotoScalerSalt,
-		default: null,
+		default: process.env.NODE_ENV === 'test' ? secretDefault : null,
 		env: 'PHOTO_SCALER_SALT',
 		sensitive: true,
 	},

--- a/src/config/server/index.js
+++ b/src/config/server/index.js
@@ -1,0 +1,188 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const chalk = require('chalk');
+const convict = require('convict');
+
+const { schema: envSchema, properties: envProperties } = require('../env');
+
+const {
+	CSRF_SECRET_ERROR,
+	OAUTH_SECRET_ERROR,
+	OAUTH_KEY_ERROR,
+	COOKIE_SECRET_ERROR,
+	SALT_ERROR,
+	secretDefault,
+	validateCookieSecret,
+	validateCsrfSecret,
+	validateOauthKey,
+	validateOauthSecret,
+	validatePhotoScalerSalt,
+	validateProtocol,
+	validateServerHost,
+} = require('./util');
+
+/**
+ * This module provides a single source of truth for application configuration
+ * info. It uses node-convict to read configuration info from, in increasing
+ * order of precedence:
+ *
+ * 1. Default value
+ * 2. File (`config.loadFile()`) - app root `config.<NODE_ENV>.json`
+ * 3. Environment variables
+ * 4. Command line arguments
+ * 5. Set and load calls (config.set() and config.load())
+ *
+ * Note that environment variables have _higher_ precedence than values in
+ * config files, so the config files will only work if environment variables
+ * are cleared.
+ *
+ * The only values that _must_ be in environment variables are the secrets that
+ * are used to interact with external systems:
+ *
+ * - `MUPWEB_OAUTH_SECRET`
+ * - `MUPWEB_OAUTH_KEY`
+ * - `PHOTO_SCALER_SALT`
+ *
+ * @module config
+ */
+const schema = Object.assign({}, envSchema, {
+	app_server: {
+		protocol: {
+			format: validateProtocol,
+			default:
+				process.env.NODE_ENV === 'production'
+					? 'http' // SSL handled by load balancer
+					: 'https',
+			env: 'DEV_SERVER_PROTOCOL', // legacy naming
+		},
+		// host: '0.0.0.0', ALWAYS 0.0.0.0
+		port: {
+			format: 'port',
+			default: 8000,
+			arg: 'app-port',
+			env: process.env.NODE_ENV !== 'test' && 'DEV_SERVER_PORT', // don't read env in tests
+		},
+		key_file: {
+			format: String,
+			default: path.resolve(os.homedir(), '.certs', 'star.dev.meetup.com.key'),
+			env: 'APP_KEY_FILE',
+		},
+		crt_file: {
+			format: String,
+			default: path.resolve(os.homedir(), '.certs', 'star.dev.meetup.com.crt'),
+			env: 'APP_CRT_FILE',
+		},
+	},
+	api: {
+		protocol: {
+			format: validateProtocol,
+			default: 'https',
+			env: 'API_PROTOCOL',
+		},
+		host: {
+			format: validateServerHost,
+			default: 'api.dev.meetup.com',
+			env: 'API_HOST',
+		},
+		timeout: {
+			format: 'int',
+			default: 10000,
+			env: 'API_TIMEOUT',
+		},
+		root_url: {
+			format: String,
+			default: '',
+		},
+	},
+	cookie_encrypt_secret: {
+		format: validateCookieSecret,
+		default: secretDefault,
+		env: process.env.NODE_ENV !== 'test' && 'COOKIE_ENCRYPT_SECRET', // don't read env in tests
+		sensitive: true,
+	},
+	csrf_secret: {
+		format: validateCsrfSecret,
+		default: secretDefault,
+		env: 'CSRF_SECRET',
+		sensitive: true,
+	},
+	oauth: {
+		auth_url: {
+			format: 'url',
+			default: 'https://secure.dev.meetup.com/oauth2/authorize',
+			env: 'OAUTH_AUTH_URL',
+		},
+		access_url: {
+			format: 'url',
+			default: 'https://secure.dev.meetup.com/oauth2/access',
+			env: 'OAUTH_ACCESS_URL',
+		},
+		secret: {
+			format: validateOauthSecret,
+			default: null,
+			env: 'MUPWEB_OAUTH_SECRET',
+			sensitive: true,
+		},
+		key: {
+			format: validateOauthKey,
+			default: null,
+			env: 'MUPWEB_OAUTH_KEY',
+			sensitive: true,
+		},
+	},
+	photo_scaler_salt: {
+		format: validatePhotoScalerSalt,
+		default: null,
+		env: 'PHOTO_SCALER_SALT',
+		sensitive: true,
+	},
+});
+
+const config = convict(schema);
+
+config.load(envProperties);
+
+// Load environment dependent configuration
+const configPath = path.resolve(
+	process.cwd(),
+	`config.${config.get('env')}.json`
+);
+
+const localConfig = fs.existsSync(configPath) ? require(configPath) : {};
+
+config.load(localConfig);
+
+config.set(
+	'api.root_url',
+	`${config.get('api.protocol')}://${config.get('api.host')}`
+);
+
+config.set('isProd', config.get('env') === 'production');
+config.set('isDev', config.get('env') === 'development');
+const appConf = config.get('app_server');
+if (
+	appConf.protocol === 'https' &&
+	(!fs.existsSync(appConf.key_file) || !fs.existsSync(appConf.crt_file))
+) {
+	const message = 'Missing HTTPS cert or key for application server!';
+	if (config.isProd) {
+		throw new Error(message);
+	}
+	console.error(chalk.red(message));
+	console.warn(
+		chalk.yellow(
+			'Re-setting protocol to HTTP - some features may not work as expected'
+		)
+	);
+	console.warn(chalk.yellow('See MWP config docs to configure HTTPS'));
+	config.set('app_server.protocol', 'http');
+}
+config.validate();
+
+module.exports = {
+	config,
+	schema,
+	properties: config.getProperties(),
+};

--- a/src/config/server/index.test.js
+++ b/src/config/server/index.test.js
@@ -1,0 +1,147 @@
+const { properties: config } = require('./');
+const {
+	COOKIE_SECRET_ERROR,
+	CSRF_SECRET_ERROR,
+	OAUTH_SECRET_ERROR,
+	OAUTH_KEY_ERROR,
+	PROTOCOL_ERROR,
+	SALT_ERROR,
+	secretDefault,
+	validateCookieSecret,
+	validateCsrfSecret,
+	validateOauthSecret,
+	validateOauthKey,
+	validatePhotoScalerSalt,
+	validateProtocol,
+	validateServerHost,
+} = require('./util');
+
+const string1 = '1';
+const string31 = 'asdfasdfasdfasdfasdfasdfasdfasd';
+const string32 = 'asdfasdfasdfasdfasdfasdfasdfasdf';
+const string36 = 'asdfasdfasdfasdfasdfasdfasdfasdfasdf';
+
+describe('validateProtocol', () => {
+	it('does not error when protocol is `http` or `https`', () => {
+		expect(() => validateProtocol('http')).not.toThrow();
+		expect(() => validateProtocol('https')).not.toThrow();
+	});
+
+	it('throws error when the protocol is not `http` or `https`', () => {
+		expect(() => validateProtocol('ftp')).toThrowError(PROTOCOL_ERROR);
+	});
+});
+
+describe('validateServerHost', () => {
+	it('throws an error for non-string values', () => {
+		expect(() => validateServerHost(null)).toThrow();
+		expect(() => validateServerHost(1234)).toThrow();
+		expect(() => validateServerHost({ foo: 'bar' })).toThrow();
+		expect(() => validateServerHost(['foo'])).toThrow();
+		expect(() => validateServerHost('foo')).not.toThrow();
+	});
+	it('throws error for dev in prod', () => {
+		const _env = process.env.NODE_ENV; // cache the 'real' value to restore later
+		process.env.NODE_ENV = 'production';
+		expect(() => validateServerHost('foo.dev.bar.com')).toThrow();
+		expect(() => validateServerHost('foo.bar.com')).not.toThrow();
+		process.env.NODE_ENV = _env; // restore original env value
+	});
+	it('throws error for dev in prod', () => {
+		const _env = process.env.NODE_ENV; // cache the 'real' value to restore later
+		process.env.NODE_ENV = 'development';
+		expect(() => validateServerHost('foo.dev.bar.com')).not.toThrow();
+		expect(() => validateServerHost('foo.bar.com')).toThrow();
+		process.env.NODE_ENV = _env; // restore original env value
+	});
+});
+
+describe('config', () => {
+	it('is a valid JS object', () => {
+		expect(config).toBeTruthy();
+		expect(config).toBeInstanceOf(Object);
+	});
+
+	it('has values for all env variables', () => {
+		expect(config.env).toBeTruthy();
+		expect(config.api).toBeTruthy();
+		expect(config.api.protocol).toBeTruthy();
+		expect(config.api.host).toBeTruthy();
+		expect(config.api.timeout).toBeTruthy();
+		expect(config.api.root_url).toBeTruthy();
+		expect(config.cookie_encrypt_secret).toBeTruthy();
+		expect(config.csrf_secret).toBeTruthy();
+		expect(config.app_server).toBeTruthy();
+		expect(config.app_server.protocol).toBeTruthy();
+		expect(config.isDev).toBeDefined();
+		expect(config.isProd).toBeDefined();
+		expect(config.oauth).toBeTruthy();
+		expect(config.oauth.auth_url).toBeTruthy();
+		expect(config.oauth.access_url).toBeTruthy();
+		expect(config.oauth.secret).toBeTruthy();
+		expect(config.oauth.key).toBeTruthy();
+		expect(config.photo_scaler_salt).toBeTruthy();
+	});
+});
+
+describe('validateCookieSecret', () => {
+	it('does not error when secret is 32 char or more', () => {
+		expect(() => validateCookieSecret(string32)).not.toThrow();
+		expect(() => validateCookieSecret(string36)).not.toThrow();
+	});
+
+	it('throws error when secret is missing or less than 32 characters', () => {
+		expect(() => validateCookieSecret(null)).toThrowError(COOKIE_SECRET_ERROR);
+		expect(() => validateCookieSecret(string31)).toThrowError(
+			COOKIE_SECRET_ERROR
+		);
+	});
+});
+
+describe('validateCsrfSecret', () => {
+	it('does not error when secret is 32 char or more', () => {
+		expect(() => validateCsrfSecret(string32)).not.toThrow();
+		expect(() => validateCsrfSecret(string36)).not.toThrow();
+	});
+
+	it('throws error when secret is missing or less than 32 characters', () => {
+		expect(() => validateCsrfSecret(null)).toThrowError(CSRF_SECRET_ERROR);
+		expect(() => validateCsrfSecret(string31)).toThrowError(CSRF_SECRET_ERROR);
+	});
+});
+
+describe('validateOauthSecret', () => {
+	it('does not error when secret is 1 char or more', () => {
+		expect(() => validateOauthSecret(string1)).not.toThrow();
+		expect(() => validateOauthSecret(string36)).not.toThrow();
+	});
+
+	it('throws error when secret is missing or empty', () => {
+		expect(() => validateOauthSecret(null)).toThrowError(OAUTH_SECRET_ERROR);
+		expect(() => validateOauthSecret('')).toThrowError(OAUTH_SECRET_ERROR);
+	});
+});
+
+describe('validateOauthKey', () => {
+	it('does not error when key is 1 char or more', () => {
+		expect(() => validateOauthKey(string1)).not.toThrow();
+		expect(() => validateOauthKey(string36)).not.toThrow();
+	});
+
+	it('throws error when key is missing or empty', () => {
+		expect(() => validateOauthKey(null)).toThrowError(OAUTH_KEY_ERROR);
+		expect(() => validateOauthKey('')).toThrowError(OAUTH_KEY_ERROR);
+	});
+});
+
+describe('validatePhotoScalerSalt', () => {
+	it('does not error when salt is 1 char or more', () => {
+		expect(() => validatePhotoScalerSalt(string1)).not.toThrow();
+		expect(() => validatePhotoScalerSalt(string36)).not.toThrow();
+	});
+
+	it('throws error when salt is missing or empty', () => {
+		expect(() => validatePhotoScalerSalt(null)).toThrowError(SALT_ERROR);
+		expect(() => validatePhotoScalerSalt('')).toThrowError(SALT_ERROR);
+	});
+});

--- a/src/config/server/util.js
+++ b/src/config/server/util.js
@@ -1,0 +1,78 @@
+const random32 = 'asdfasdfasdfasdfasdfasdfasdfasdf';
+const secretDefault = (process.env.NODE_ENV !== 'production' && random32) || ''; // no prod default
+
+const CSRF_SECRET_ERROR = 'CSRF Secret must be a random 32+ char string';
+const OAUTH_SECRET_ERROR = 'Invalid OAUTH Secret';
+const OAUTH_KEY_ERROR = 'Invalid OAUTH Key';
+const COOKIE_SECRET_ERROR = 'Cookie Secret must be a random 32+ char string';
+const SALT_ERROR = 'Invalid Photo Scaler Salt';
+
+const validateCookieSecret = secret => {
+	if (!secret || secret.toString().length < 32) {
+		throw new Error(COOKIE_SECRET_ERROR);
+	}
+};
+
+const validateCsrfSecret = secret => {
+	if (!secret || secret.toString().length < 32) {
+		throw new Error(CSRF_SECRET_ERROR);
+	}
+};
+
+const validateOauthSecret = secret => {
+	if (!secret || secret.toString().length < 1) {
+		throw new Error(OAUTH_SECRET_ERROR);
+	}
+};
+
+const validateOauthKey = key => {
+	if (!key || key.toString().length < 1) {
+		throw new Error(OAUTH_KEY_ERROR);
+	}
+};
+
+const validatePhotoScalerSalt = salt => {
+	if (!salt || salt.toString().length < 1) {
+		throw new Error(SALT_ERROR);
+	}
+};
+
+const PROTOCOL_ERROR = 'Protocol must be http or https';
+
+const validateProtocol = protocol => {
+	if (!['http', 'https'].includes(protocol)) {
+		throw new Error(PROTOCOL_ERROR);
+	}
+};
+
+const DEV_SUBSTRING = '.dev.';
+const validateServerHost = host => {
+	if (typeof host !== 'string') {
+		throw new Error('Server host property must be a string');
+	}
+	const isDev = process.env.NODE_ENV === 'development' || !process.env.NODE_ENV;
+	if (process.env.NODE_ENV === 'production' && host.includes(DEV_SUBSTRING)) {
+		throw new Error(
+			`Server host ${host} must not include '.dev.' in production`
+		);
+	}
+	if (isDev && !host.includes(DEV_SUBSTRING)) {
+		throw new Error(`Server host ${host} must include '.dev.' in development`);
+	}
+};
+
+module.exports = {
+	CSRF_SECRET_ERROR,
+	OAUTH_SECRET_ERROR,
+	OAUTH_KEY_ERROR,
+	COOKIE_SECRET_ERROR,
+	SALT_ERROR,
+	secretDefault,
+	validateCookieSecret,
+	validateCsrfSecret,
+	validateOauthKey,
+	validateOauthSecret,
+	validatePhotoScalerSalt,
+	validateProtocol,
+	validateServerHost,
+};


### PR DESCRIPTION
This PR documents the config that is currently managed by mwp-cli, although it is expected to be spun off into its own package in the near future.

In addition, the application server config script has been moved over from MWP - although MWP is the only consumer of that config, managing it here helps keep the overall system internally consistent - CONFIG IS MANAGED IN A SINGLE PLACE.

The server config script has been converted to Node-friendly ES6 (i.e. no ES6 `import`/`export`), and some helper functions/constants have been moved to a separate `util.js` script. Otherwise, the functionality is untouched so it probably doesn't need in-depth review.