### PR TITLE
make the server config a getter

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -5,5 +5,5 @@ module.exports = {
 	package: require('./package'),
 	paths: require('./paths'),
 	webpack: require('./webpack'),
-	server: require('./server'),
+	getServer: () => require('./server'), // this is a getter because it validates environment config at runtime
 };


### PR DESCRIPTION
since the server config module validates as soon as it's imported, it will fail in an environment that only provides build-time environment variables, e.g. Travis