### PR TITLE
added support for INTERCOM_APP_ID config

### DIFF
--- a/src/config/README.md
+++ b/src/config/README.md
@@ -36,3 +36,9 @@ module.
 The `/server` module defines the runtime configuration of the Node application
 server. It is essentially an extension of the `/env` config, but adds a few more
 host and authentication configuration values.
+
+## Known config keys
+
+| Key | Description |
+| ------------- | ------------- |
+| INTERCOM_APP_ID  | Intercom AppID associated with Meetup Intercom account that is used for this 3rd Party messaging/onboarding service/component. Available on client and server. |

--- a/src/config/README.md
+++ b/src/config/README.md
@@ -37,7 +37,11 @@ The `/server` module defines the runtime configuration of the Node application
 server. It is essentially an extension of the `/env` config, but adds a few more
 host and authentication configuration values.
 
-## Known config keys
+## `process.env` keys supported in client code
+
+Although process.env is typically only available in server-side code, our bundling process can automatically inject certain environment values into the client bundle wherever it finds a supported process.env.YOUR_ENV_VAR expression.
+
+The following environment variables are supported - clients are responsible for populating them in the build environment:
 
 | Key | Description |
 | ------------- | ------------- |

--- a/src/config/server/index.test.js
+++ b/src/config/server/index.test.js
@@ -38,7 +38,7 @@ describe('validateServerHost', () => {
 		expect(() => validateServerHost(1234)).toThrow();
 		expect(() => validateServerHost({ foo: 'bar' })).toThrow();
 		expect(() => validateServerHost(['foo'])).toThrow();
-		expect(() => validateServerHost('foo')).not.toThrow();
+		expect(() => validateServerHost('foo.dev.')).not.toThrow();
 	});
 	it('throws error for dev in prod', () => {
 		const _env = process.env.NODE_ENV; // cache the 'real' value to restore later

--- a/src/config/webpack/browserAppConfig.js
+++ b/src/config/webpack/browserAppConfig.js
@@ -73,6 +73,7 @@ function getConfig(localeCode) {
 		plugins: [
 			new webpack.EnvironmentPlugin({
 				NODE_ENV: 'development', // required for prod build of React (specify default)
+				INTERCOM_APP_ID: null,   // only needs to be overriden if application wants Intercom config available on client and server
 			}),
 			new webpack.DllReferencePlugin({
 				context: '.',


### PR DESCRIPTION
As per: https://meetup.atlassian.net/browse/MUP-15692

This PR is to add support for configuring INTERCOM_APP_ID, needed to support the 3rd Party service Intercom that Meetup sometimes uses for messaging users, onboarding, and support campaigns.