### PR TITLE
fix push to master - push everything , every launch

### DIFF
--- a/src/commands/txCommands/pushNewContent.js
+++ b/src/commands/txCommands/pushNewContent.js
@@ -36,13 +36,14 @@ const pushResource$ = poData =>
 		.flatMap(([gitBranch, branchResourceExists]) => {
 			if (Object.keys(poData).length) {
 				const pushed$ = branchResourceExists
-					? txlib.updateResource$
-					: txlib.createResource$;
+					? txlib.updateResource$.do(() => console.log(`new content - update ${gitBranch}`))
+					: txlib.createResource$.do(() => console.log(`new content - create ${gitBranch}`));
 				return pushed$(gitBranch, poData);
 			} else {
 				return Rx.Observable.if(
 					() => branchResourceExists,
 					txlib.deleteResource$(gitBranch)
+					.do(() => console.log(`no new content - delete ${gitBranch}`))
 				);
 			}
 		});

--- a/src/commands/txCommands/util/index.js
+++ b/src/commands/txCommands/util/index.js
@@ -182,8 +182,8 @@ const readResource$ = (slug, project = PROJECT) =>
 		project,
 		slug
 	)
-	.do(null, () => console.log(`error readResource$ ${slug} ${project}`))
-	.retry(5);
+	.retry(5)
+	.do(null, () => console.log(`error readResource$ ${slug} ${project}`));
 
 const updateResource$ = (slug, content, project = PROJECT) => {
 	// allow override for push to mup-web-master
@@ -210,8 +210,8 @@ const uploadTrnsMaster$ = ([lang_tag, content]) =>
 		MASTER_RESOURCE,
 		lang_tag,
 		resourceContent(MASTER_RESOURCE, content)
-	).map(response => [lang_tag,response])
-	.do(([lang_tag,response]) => {
+	)
+	.do(response => {
 			console.log(lang_tag);
 			console.log(response);
 		},

--- a/src/commands/txCommands/util/index.js
+++ b/src/commands/txCommands/util/index.js
@@ -181,7 +181,9 @@ const readResource$ = (slug, project = PROJECT) =>
 	Rx.Observable.bindNodeCallback(tx.sourceLanguageMethods.bind(tx))(
 		project,
 		slug
-	).retry(5);
+	)
+	.do(null, () => console.log(`error readResource$ ${slug} ${project}`))
+	.retry(5);
 
 const updateResource$ = (slug, content, project = PROJECT) => {
 	// allow override for push to mup-web-master
@@ -208,7 +210,13 @@ const uploadTrnsMaster$ = ([lang_tag, content]) =>
 		MASTER_RESOURCE,
 		lang_tag,
 		resourceContent(MASTER_RESOURCE, content)
-	);
+	).map(response => [lang_tag,response])
+	.do(([lang_tag,response]) => {
+			console.log(lang_tag);
+			console.log(response);
+		},
+		() => console.log(`error uploadTrnsMaster$ ${lang_tag}`)
+	)
 
 const uploadTranslation$ = ([lang_tag, content]) =>
 	Rx.Observable.bindNodeCallback(tx.translationStringsPutMethod.bind(tx))(


### PR DESCRIPTION
I noticed that pushing translated content to master wasn't working as it should. The primary culprit is the change I made in a failed effort to support translation changes in transifex. After thinking it over, I decided that it would be better to have a simpler system where content flows only in one direction than to support a wider set of use cases. One of the larger failing of the tx integration is that it can be difficult to reason about. This will make it significantly simpler.

Rather than revert the change set from August, I decided to only change what was necessary. I also kept most of the logging that helped me debug what was wrong.