### PR TITLE
Disable eslint webpack loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [1.4]
+
+- **New feature** - eslint-loader removed from webpack compile.
+
 # [1.3]
 
 - **New feature** - `mope tx status` to get list of transifex resources and

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 1.3.$(CI_BUILD_NUMBER)
+VERSION ?= 1.4.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "coveralls": "2.13.1",
     "css-loader": "0.28.4",
     "eslint": "4.2.0",
-    "eslint-loader": "1.9.0",
     "gettext-parser": "1.2.2",
     "github": "12.0.1",
     "glob": "7.1.2",

--- a/src/config/webpack/rules.js
+++ b/src/config/webpack/rules.js
@@ -16,7 +16,7 @@ module.exports = {
 			exclude: paths.src.asset,
 		},
 		browser: {
-			// standard ES5 transpile through Babel, with linting
+			// standard ES5 transpile through Babel
 			test: /\.jsx?$/,
 			include: [paths.src.browser.app, paths.packages.webComponents.src],
 			exclude: paths.src.asset,
@@ -29,8 +29,7 @@ module.exports = {
 						presets: babelrc.presets.browser,
 					},
 				},
-				{ loader: 'eslint-loader' },
-			],
+			]
 		},
 		server: {
 			test: /\.jsx?$/,


### PR DESCRIPTION
eslint complains too much about things I don't care about early in the dev process