### PR TITLE
allow owner/repo to be supplied to 'repo' arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [2.1]
+
+- Support arbitrary repo owner for `gh status` command - enables status in PRs
+  from forked repos
+
 # [2.0]
 
 - **Breaking change** - `file-loader!` and `raw-loader!` will no longer work inline.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 2.0.$(CI_BUILD_NUMBER)
+VERSION ?= 2.1.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/src/commands/ghCommands/status.js
+++ b/src/commands/ghCommands/status.js
@@ -28,7 +28,7 @@ module.exports = {
 				repo: {
 					alias: 'r',
 					demandOption: true,
-					describe: 'repo name/slug',
+					describe: 'repo slug in the form :owner/:repo',
 				},
 				context: {
 					demandOption: true,
@@ -49,6 +49,13 @@ module.exports = {
 						`Full 40-character SHA-1 value must be provided - recieved ${argv.commit}`
 					);
 				}
+				if (argv.repo.split('/').length !== 2) {
+					console.warn(
+						chalk.yellow(
+							`'repo' should be in the form :owner/:repo - received ${repo}`
+						)
+					);
+				}
 				return true;
 			}),
 	handler: ({ state, commit, token, repo, context, description, target }) => {
@@ -56,10 +63,16 @@ module.exports = {
 			type: 'token',
 			token,
 		});
+		let [owner, repoName] = repo.split('/');
+		if (!repoName) {
+			// assume that just the repoName was supplied, owner is meetup
+			repoName = owner;
+			owner = 'meetup';
+		}
 		github.repos
 			.createStatus({
-				owner: 'meetup',
-				repo,
+				owner,
+				repo: repoName,
 				sha: commit,
 				state,
 				description,


### PR DESCRIPTION
This should allow us to set PR status for PRs that come from a third-party fork (e.g. the AgilityIO PRs). Travis will supply the downstream repo name as `owner/repo` in the `TRAVIS_PULL_REQUEST_SLUG` env variable during a build, which can then be passed to the script invocation as a `GITHUB_REPO` env var or `--repo` CLI option