### PR TITLE
WP-624 adjusting pull all for main

### DIFF
--- a/docs/tx.md
+++ b/docs/tx.md
@@ -42,11 +42,9 @@ content locally and on Transifex.
   pulled content into the associated by locale `src/trns/po/{localeCode}.po` files.
     * If you'd like to have a history of each change based on resource add a flag of `-c`
     and it will create a unique commit for each resource that has a change to commit.
-    * If you are maintaining an `all_translations` resource for translators to be able
-    to edit any key that is in the master project you will need to add a flag of 
-    `-downloadAllTranslationsResource` to have this resource downloaded. Please note,
-    this resource will be pulled *first* then all other resources will be downloaded
-    after and applied on top of it.
+    * Please note that if your project has a `all_translations` resource for translators
+    to be able to edit any key that is in the master project, this resource will be pulled
+    *first* then all other resources will be downloaded after and applied on top of it.
 
   Commit result, create PR, and merge PR after Travis build has passed.
 

--- a/docs/tx.md
+++ b/docs/tx.md
@@ -42,6 +42,11 @@ content locally and on Transifex.
   pulled content into the associated by locale `src/trns/po/{localeCode}.po` files.
     * If you'd like to have a history of each change based on resource add a flag of `-c`
     and it will create a unique commit for each resource that has a change to commit.
+    * If you are maintaining an `all_translations` resource for translators to be able
+    to edit any key that is in the master project you will need to add a flag of 
+    `-downloadAllTranslationsResource` to have this resource downloaded. Please note,
+    this resource will be pulled *first* then all other resources will be downloaded
+    after and applied on top of it.
 
   Commit result, create PR, and merge PR after Travis build has passed.
 

--- a/src/commands/txCommands/pullAll.js
+++ b/src/commands/txCommands/pullAll.js
@@ -4,9 +4,13 @@ const txlib = require('./util');
 const pullResourceTrns = require('./util/pullResourceTrns');
 const gitHelpers = require('./util/gitHelpers');
 
+
+const allTranslationsResource$ = Rx.Observable.of([txlib.ALL_TRANSLATIONS_RESOURCE]);
+
 const getProjectResourcesList$ =
 	txlib.resources$
-		.flatMap(Rx.Observable.from);
+		.flatMap(Rx.Observable.from)
+		.filter(resource => resource !== txlib.ALL_TRANSLATIONS_RESOURCE);
 
 /**
  * Kicks off process to pull an individual resources trns
@@ -35,7 +39,8 @@ module.exports = {
 		txlib.checkEnvVars();
 		console.log(chalk.magenta('Start pulling all resources process...'));
 
-		getProjectResourcesList$
+		Rx.Observable
+			.merge(allTranslationsResource$, getProjectResourcesList$)
 			.flatMap(pullResource$, 1)
 			.flatMap(resource => {
 				if (!argv.gitCommit) {

--- a/src/commands/txCommands/pullAll.js
+++ b/src/commands/txCommands/pullAll.js
@@ -31,7 +31,7 @@ const pullResource$ = (resource) => {
 
 module.exports = {
 	command: 'pullAll',
-	description: 'Downloads all translations from resources from Transifex, ordered by most recently updated',
+	description: 'Downloads all translations for resources from Transifex, ordered by most recently updated',
 	builder: yarg =>
 		yarg.option({
 			commit: {

--- a/src/commands/txCommands/pullAll.js
+++ b/src/commands/txCommands/pullAll.js
@@ -54,7 +54,6 @@ module.exports = {
 			// See longer description above in `getProjectResourcesList$` but we essentially
 			// want allTranslationsResource$ downloaded first, then all feature branch resources
 			.merge(allTranslationsResource$(argv.downloadAllTranslationsResource), getProjectResourcesList$)
-			// .filter(resources => resources.length)
 			.flatMap(pullResource$, 1)
 			.flatMap(resource => {
 				if (!argv.gitCommit) {

--- a/src/commands/txCommands/pullAll.js
+++ b/src/commands/txCommands/pullAll.js
@@ -5,42 +5,56 @@ const pullResourceTrns = require('./util/pullResourceTrns');
 const gitHelpers = require('./util/gitHelpers');
 
 
-const allTranslationsResource$ = Rx.Observable.of([txlib.ALL_TRANSLATIONS_RESOURCE]);
+const allTranslationsResource$ = downloadAllTranslationsResource =>
+	downloadAllTranslationsResource
+	? Rx.Observable.of(txlib.ALL_TRANSLATIONS_RESOURCE)
+	: Rx.Observable.empty();
 
 const getProjectResourcesList$ =
 	txlib.resources$
 		.flatMap(Rx.Observable.from)
+		// We exclude the ALL_TRANSLATIONS_RESOURCE from the list as we want to always
+		// downloaded this first, this will allow other resources to be applied on top of
+		// any changes in that resource. Hopefully, this should prevent any changes in
+		// feature branches from being overridden by this resource
 		.filter(resource => resource !== txlib.ALL_TRANSLATIONS_RESOURCE);
 
 /**
- * Kicks off process to pull an individual resources trns
- * @param  {String} resource resource slug to be used when we pull translations
+ * Kicks off process to downloaded an individual resources trns
+ * @param  {String} resource resource slug to be used when we downloaded translations
  * @return {Observable} Observable of tx process
  */
 const pullResource$ = (resource) => {
 	console.log(chalk.cyan(`Starting tx:pull for '${resource}'`));
 	return pullResourceTrns.pullResourceContent$(resource)
-		.toArray() // wait until all content has been pulled before moving on to next tasks
+		.toArray() // wait until all content has been downloaded before moving on to next tasks
 		.do(() => console.log(chalk.green(`\nCompleted tx:pull for '${resource}'`)))
 		.map(() => resource);
 };
 
 module.exports = {
 	command: 'pullAll',
-	description: 'Pull all translations from resources from Transifex, ordered by most recently updated',
+	description: 'Downloads all translations from resources from Transifex, ordered by most recently updated',
 	builder: yarg =>
 		yarg.option({
-			gitCommit: {
+			commit: {
 				alias: 'c',
 				default: false
+			},
+			downloadAllTranslationsResource: {
+				alias: 'allResource',
+				default: false,
 			},
 		}),
 	handler: argv => {
 		txlib.checkEnvVars();
-		console.log(chalk.magenta('Start pulling all resources process...'));
+		console.log(chalk.magenta('Start downloading all resources process...'));
 
 		Rx.Observable
-			.merge(allTranslationsResource$, getProjectResourcesList$)
+			// See longer description above in `getProjectResourcesList$` but we essentially
+			// want allTranslationsResource$ downloaded first, then all feature branch resources
+			.merge(allTranslationsResource$(argv.downloadAllTranslationsResource), getProjectResourcesList$)
+			// .filter(resources => resources.length)
 			.flatMap(pullResource$, 1)
 			.flatMap(resource => {
 				if (!argv.gitCommit) {

--- a/src/commands/txCommands/pullAll.js
+++ b/src/commands/txCommands/pullAll.js
@@ -56,7 +56,7 @@ module.exports = {
 			.merge(allTranslationsResource$(argv.downloadAllTranslationsResource), getProjectResourcesList$)
 			.flatMap(pullResource$, 1)
 			.flatMap(resource => {
-				if (!argv.gitCommit) {
+				if (!argv.commit) {
 					return Rx.Observable.empty();
 				}
 				const commitMessage = `tx:pull for ${resource.replace(/-/g, '_')}`;

--- a/src/commands/txCommands/pullAll.js
+++ b/src/commands/txCommands/pullAll.js
@@ -10,9 +10,9 @@ const getProjectResourcesList$ =
 		// downloaded first, this will allow other resources to be applied on top of
 		// any changes in that resource. Hopefully, this should prevent any changes in
 		// feature branches from being overridden by this resource
-		.map(resource =>
-			resource
-				.sort((a, b) => a === txlib.ALL_TRANSLATIONS_RESOURCE ? -1 : 1)
+		.map(resources =>
+			resources
+				.sort(a => a === txlib.ALL_TRANSLATIONS_RESOURCE ? -1 : 1)
 		)
 		.flatMap(Rx.Observable.from);
 

--- a/src/commands/txCommands/util/gitHelpers.js
+++ b/src/commands/txCommands/util/gitHelpers.js
@@ -22,7 +22,7 @@ const commit$ = (commitMessage, args) => {
 			const command = `git commit -m ${JSON.stringify(commitMessage)} ${args}`;
 			return child_process$(command)
 			.do(() => {
-				console.log(chalk.green(command));
+				console.log(chalk.grey(command));
 			});
 		});
 };

--- a/src/commands/txCommands/util/index.js
+++ b/src/commands/txCommands/util/index.js
@@ -17,7 +17,7 @@ const TX_PW = process.env.TRANSIFEX_PW;
 const PROJECT = packageConfig.txProject;
 const PROJECT_MASTER = `${PROJECT}-master`; // separate project so translators don't confuse with branch content
 const MASTER_RESOURCE = 'master';
-const ALL_TRANSLATIONS_RESOURCE = 'all_translations'; // #TODO: temp until me and yanyi merge branches
+const ALL_TRANSLATIONS_RESOURCE = 'all_translations';
 
 const tx = new Transifex({
 	project_slug: PROJECT,

--- a/src/commands/txCommands/util/index.js
+++ b/src/commands/txCommands/util/index.js
@@ -17,6 +17,7 @@ const TX_PW = process.env.TRANSIFEX_PW;
 const PROJECT = packageConfig.txProject;
 const PROJECT_MASTER = `${PROJECT}-master`; // separate project so translators don't confuse with branch content
 const MASTER_RESOURCE = 'master';
+const ALL_TRANSLATIONS_RESOURCE = 'all_translations'; // #TODO: temp until me and yanyi merge branches
 
 const tx = new Transifex({
 	project_slug: PROJECT,
@@ -384,6 +385,7 @@ const resourcesComplete$ = resourceCompletion$
 module.exports = {
 	allLocalPoTrns$,
 	allLocalPoTrnsWithFallbacks$,
+	ALL_TRANSLATIONS_RESOURCE,
 	checkEnvVars,
 	createResource$,
 	deleteResource$,


### PR DESCRIPTION
### Background
The translation flow currently does not allow for corrections to copy without developer work. Let's change that.

1. Add a new resource to the mup-web project ("main" or something of that sort) that includes all translations in the project.
2. Every time we pull translations, if "main" exists, then pull and update all translations in mup-web. Then pull all the rest of the resources.
3. Every time we push to master, also update and sync main to match the current state of mup-web.
4. ????
5. Profit!!!!!!

### DoD
1. Modify the `pullAll` mwp-cli command to include a `all_translations` resource, but have it download first so that changes in other branches are applied on top of it
