### PR TITLE
New format for transpiled TRN source JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,49 +1,60 @@
+# [5.0]
+
+* **Refactored** `build trn` now writes JSON as a map of
+  `{ [localeCode]: messages }`. Consumer apps **must** upgrade `mwp-i18n` to
+  version 12.1 or later in order for translations to continue working.
+
+* **New feature** `build trn` can also now write a single translation source
+  module for each translated component that contains translations for all
+  supported languages rather than writing separate source modules for each
+  supported language. Set `config.combineLanguages` to `true` in your app's
+  `package.json` to enable this build option.
+
 # [4.0]
 
-- **Removed** `src/config` has been moved to `mwp-config` package managed by
+* **Removed** `src/config` has been moved to `mwp-config` package managed by
   MWP repo
 
 # [3.0]
 
-- Oauth values are no longer part of config - they are not used in MWP v10.2+
+* Oauth values are no longer part of config - they are not used in MWP v10.2+
 
 # [2.2]
 
-- Support for `webfont` alias, which will resolve to `src/assets/fonts` for all
+* Support for `webfont` alias, which will resolve to `src/assets/fonts` for all
   languages except Russian, which will resolve to `src/assets/fonts/ru-RU`. This
   alias is useful for referencing a separate Cyrillic-supporting webfont.
 
 # [2.1]
 
-- Support arbitrary repo owner for `gh status` command - enables status in PRs
+* Support arbitrary repo owner for `gh status` command - enables status in PRs
   from forked repos
 
 # [2.0]
 
-- **Breaking change** - `file-loader!` and `raw-loader!` will no longer work inline.
+* **Breaking change** - `file-loader!` and `raw-loader!` will no longer work inline.
   Webpack config will handle the them based on extension.
 
 # [1.5]
 
-- **New feature** - `mope tx keys` displays list of resources and their keys
+* **New feature** - `mope tx keys` displays list of resources and their keys
 
 # [1.4]
 
-- **New feature** - eslint-loader removed from webpack compile.
+* **New feature** - eslint-loader removed from webpack compile.
 
 # [1.3]
 
-- **New feature** - `mope tx status` to get list of transifex resources and
+* **New feature** - `mope tx status` to get list of transifex resources and
   their completion status.
-
 
 # [1.2]
 
-- **New feature** - `mope gh status` to set PR status. Run `mope gh status -h`
+* **New feature** - `mope gh status` to set PR status. Run `mope gh status -h`
   for more details.
 
 # [1.1]
 
-- **Potentially breaking change** - Default `asset_server.path` updated from
+* **Potentially breaking change** - Default `asset_server.path` updated from
   `/static` to `/mu_static`. Downstream consumers will need to update any code
   that assumes a particular `asset_server.path`

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 4.0.$(CI_BUILD_NUMBER)
+VERSION ?= 5.0.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,15 +1,12 @@
 const yargs = require('yargs');
 
-const run = () => {
-	const argv = yargs
+const run = () =>
+	yargs
 		.commandDir('commands') // commands are in the './commands/' dir
 		.demandCommand() // require a command to be used - no default behavior
 		.strict() // show help when unsupported commands/options are used
 		.help().argv; // build '--help' output and return parsed args as plain object
 
-	/** The following will be run whenever CLI is run **/
-	console.debug(argv);
-};
 module.exports = {
 	run,
 };

--- a/src/commands/buildCommands/browser.js
+++ b/src/commands/buildCommands/browser.js
@@ -15,6 +15,7 @@ const buildBrowserApp = localeCode => {
 		chalk.blue(`building browser app (${chalk.yellow(localeCode)})...`)
 	);
 	const config = getBrowserAppConfig(localeCode);
+        config.resolve.alias.trns = require('path').resolve(paths.src.trns, 'modules');
 	webpack(config, (err, stats) => {
 		const relativeBundlePath = getBundlePath(stats, localeCode);
 		console.log(chalk.blue(`built ${relativeBundlePath}`));
@@ -31,6 +32,7 @@ module.exports = {
 			chalk.blue('building browser bundle using current vendor bundles')
 		);
 		// TODO : fork a new child process?
-		argv.locales.forEach(buildBrowserApp);
+		//argv.locales.forEach(buildBrowserApp);
+		buildBrowserApp('en-US');
 	},
 };

--- a/src/commands/buildCommands/browser.js
+++ b/src/commands/buildCommands/browser.js
@@ -15,7 +15,6 @@ const buildBrowserApp = localeCode => {
 		chalk.blue(`building browser app (${chalk.yellow(localeCode)})...`)
 	);
 	const config = getBrowserAppConfig(localeCode);
-        config.resolve.alias.trns = require('path').resolve(paths.src.trns, 'modules');
 	webpack(config, (err, stats) => {
 		const relativeBundlePath = getBundlePath(stats, localeCode);
 		console.log(chalk.blue(`built ${relativeBundlePath}`));
@@ -32,7 +31,6 @@ module.exports = {
 			chalk.blue('building browser bundle using current vendor bundles')
 		);
 		// TODO : fork a new child process?
-		//argv.locales.forEach(buildBrowserApp);
-		buildBrowserApp('en-US');
+		argv.locales.forEach(buildBrowserApp);
 	},
 };

--- a/src/commands/buildCommands/trn.js
+++ b/src/commands/buildCommands/trn.js
@@ -25,7 +25,6 @@ const writeTrnModules = messagesByLocale => ({ filename, msgids }) => {
 		const relPath = path.relative(paths.srcPath, filename);
 		const destFilename = path.resolve(
 			MODULES_PATH,
-			localeCode,
 			`${relPath}.json`
 		);
 		const destDirname = path.dirname(destFilename);

--- a/src/commands/buildCommands/trn.js
+++ b/src/commands/buildCommands/trn.js
@@ -12,28 +12,24 @@ const {
 const MODULES_PATH = path.resolve(paths.repoRoot, 'src/trns/modules/');
 
 const writeTrnModules = messagesByLocale => ({ filename, msgids }) => {
-	locales.forEach(localeCode => {
+	const trns = locales.reduce((acc, localeCode) => {
 		if (!messagesByLocale[localeCode]) {
 			messagesByLocale[localeCode] = {};
 		}
 		// create object of trns for current localeCode
-		const trnsForLocale = msgids.reduce((trns, msgid) => {
+		acc[localeCode] = msgids.reduce((trns, msgid) => {
 			trns[msgid] = messagesByLocale[localeCode][msgid];
 			return trns;
 		}, {});
-		// write the object to a file
-		const relPath = path.relative(paths.srcPath, filename);
-		const destFilename = path.resolve(
-			MODULES_PATH,
-			`${relPath}.json`
-		);
-		const destDirname = path.dirname(destFilename);
-		mkdirp.sync(destDirname);
-		fs.appendFileSync(
-			destFilename,
-			`${JSON.stringify(trnsForLocale, null, 2)}\n`
-		);
-	});
+		return acc;
+	}, {});
+	console.log(JSON.stringify(trns, null, 2));
+
+	const relPath = path.relative(paths.srcPath, filename);
+	const destFilename = path.resolve(MODULES_PATH, `${relPath}.json`);
+	const destDirname = path.dirname(destFilename);
+	mkdirp.sync(destDirname);
+	fs.writeFileSync(destFilename, `${JSON.stringify(trns, null, 2)}\n`);
 };
 
 const componentTrnDefinitions$ = localTrns$.map(trnsFromFile => ({

--- a/src/commands/buildCommands/trn.js
+++ b/src/commands/buildCommands/trn.js
@@ -29,7 +29,7 @@ const writeTrnModules = messagesByLocale => ({ filename, msgids }) => {
 		);
 		const destDirname = path.dirname(destFilename);
 		mkdirp.sync(destDirname);
-		fs.writeFileSync(
+		fs.appendFileSync(
 			destFilename,
 			`${JSON.stringify(trnsForLocale, null, 2)}\n`
 		);

--- a/src/commands/buildCommands/trn.js
+++ b/src/commands/buildCommands/trn.js
@@ -1,9 +1,11 @@
+const { promisify } = require('util');
 const child_process = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const chalk = require('chalk');
 const mkdirp = require('mkdirp');
 
-const { paths, locales } = require('mwp-config');
+const { paths, locales, package: packageConfig } = require('mwp-config');
 const {
 	allLocalPoTrnsWithFallbacks$,
 	localTrns$,
@@ -11,7 +13,17 @@ const {
 
 const MODULES_PATH = path.resolve(paths.repoRoot, 'src/trns/modules/');
 
+const writeFile = promisify(fs.writeFile);
+
+const writeTrnFile = (destFilename, trns) => {
+	const destDirname = path.dirname(destFilename);
+	mkdirp.sync(destDirname);
+	return writeFile(destFilename, `${JSON.stringify(trns, null, 2)}\n`);
+};
+
 const writeTrnModules = messagesByLocale => ({ filename, msgids }) => {
+	// create a single `{ [localeCode]: messages }` map - this routine cleans
+	// out unused metadata from `messagesByLocale`
 	const trns = locales.reduce((acc, localeCode) => {
 		if (!messagesByLocale[localeCode]) {
 			messagesByLocale[localeCode] = {};
@@ -23,13 +35,26 @@ const writeTrnModules = messagesByLocale => ({ filename, msgids }) => {
 		}, {});
 		return acc;
 	}, {});
-	console.log(JSON.stringify(trns, null, 2));
 
-	const relPath = path.relative(paths.srcPath, filename);
-	const destFilename = path.resolve(MODULES_PATH, `${relPath}.json`);
-	const destDirname = path.dirname(destFilename);
-	mkdirp.sync(destDirname);
-	fs.writeFileSync(destFilename, `${JSON.stringify(trns, null, 2)}\n`);
+	if (packageConfig.combineLanguages) {
+		// one trn file, all trns
+		const relPath = path.relative(paths.srcPath, filename);
+		const destFilename = path.resolve(MODULES_PATH, `${relPath}.json`);
+		return writeTrnFile(destFilename, trns);
+	}
+	// one trn file per supported locale
+	return Promise.all(
+		locales.map(localeCode => {
+			const langTrns = { [localeCode]: trns[localeCode] };
+			const relPath = path.relative(paths.srcPath, filename);
+			const destFilename = path.resolve(
+				MODULES_PATH,
+				localeCode,
+				`${relPath}.json`
+			);
+			return writeTrnFile(destFilename, langTrns);
+		})
+	);
 };
 
 const componentTrnDefinitions$ = localTrns$.map(trnsFromFile => ({
@@ -49,17 +74,29 @@ const componentTrnDefinitions$ = localTrns$.map(trnsFromFile => ({
  *   react-intl babel plugin output for each component that calls `defineMessages`
  */
 const buildTrnModules = () =>
-	allLocalPoTrnsWithFallbacks$.mergeMap(
-		messagesByLocale =>
-			componentTrnDefinitions$.do(writeTrnModules(messagesByLocale)) // loop over components that define TRNs // write the files
+	allLocalPoTrnsWithFallbacks$.mergeMap(messagesByLocale =>
+		componentTrnDefinitions$.do(writeTrnModules(messagesByLocale)).toArray()
 	);
 
 function main() {
 	console.log('Cleaning TRN modules directory');
 	child_process.execSync(`rm -rf ${MODULES_PATH}`);
 
-	console.log('Transpiling TRN source to JSON');
-	buildTrnModules().toPromise().catch(err => console.error(err));
+	console.log('Transpiling TRN source to JSON...');
+	buildTrnModules().toPromise().then(
+		trnDefs => {
+			console.log(
+				chalk.green(
+					`Wrote TRN modules for ${trnDefs.length} components`
+				)
+			);
+		},
+		err => {
+			console.error(chalk.red('TRN module build failed'));
+			console.error(chalk.red(err.toString()));
+			process.exit(1);
+		}
+	);
 }
 
 module.exports = {


### PR DESCRIPTION
In order to move toward allowing MWP applications to support all languages in a single bundle, we need to update the format of the transpiled TRN JSON so that translations for multiple languages can co-exist.

This branch updates the format from this:

```js
{ "trn.key.one": "stuff that is translated" }
```

to this:

```js
{
  "en-US": { "trn.key.one": "stuff that is translated" }
}
```

it also adds support for a `config.combineLanguages` flag in an applications `package.json` that will write combined-language source JSON that looks like this:

```js
{
  "en-US": { "trn.key.one": "stuff that is translated" },
  "fr-FR": { "trn.key.one": "des choses qui sont traduites" },
  ...
}
```

Follow-on updates to MWP are needed in order to correctly parse the TRN source - this is a breaking change for that reason.