### PR TITLE
WP 639 build combined lang bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # [6.0]
 
 * **Refactored** `build trn` and `run` will both bundle the app code so that a
-  single bundle supports all languages - this makes for a very large app bundle,
-  but that should be fine in dev and it avoids having to hassle with running the
-  app with `--locales` options
+  single bundle supports all languages _in development_ - this makes for a very
+  large app bundle, but that should be fine in dev and it avoids having to
+  hassle with running the app with `--locales` options
 
 * **New feature** `build [server|browser]` will now write a single bundle
   supporting all languages if the calling application specifies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# [6.0]
+
+* **Refactored** `build trn` and `run` will both bundle the app code so that a
+  single bundle supports all languages - this makes for a very large app bundle,
+  but that should be fine in dev and it avoids having to hassle with running the
+  app with `--locales` options
+
+* **New feature** `build [server|browser]` will now write a single bundle
+  supporting all languages if the calling application specifies
+  `config.combineLanguages: true` in its `package.json`.
+
 # [5.0]
 
 * **Refactored** `build trn` now writes JSON as a map of

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 5.0.$(CI_BUILD_NUMBER)
+VERSION ?= 6.0.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/src/commands/buildCommands/trn.js
+++ b/src/commands/buildCommands/trn.js
@@ -39,7 +39,11 @@ const writeTrnModules = messagesByLocale => ({ filename, msgids }) => {
 	if (packageConfig.combineLanguages) {
 		// one trn file, all trns
 		const relPath = path.relative(paths.srcPath, filename);
-		const destFilename = path.resolve(MODULES_PATH, `${relPath}.json`);
+		const destFilename = path.resolve(
+			MODULES_PATH,
+			'combined',
+			`${relPath}.json`
+		);
 		return writeTrnFile(destFilename, trns);
 	}
 	// one trn file per supported locale

--- a/src/commands/buildCommands/trn.js
+++ b/src/commands/buildCommands/trn.js
@@ -36,7 +36,10 @@ const writeTrnModules = messagesByLocale => ({ filename, msgids }) => {
 		return acc;
 	}, {});
 
-	if (packageConfig.combineLanguages) {
+	if (
+		packageConfig.combineLanguages ||
+		process.env.NODE_ENV !== 'production'
+	) {
 		// one trn file, all trns
 		const relPath = path.relative(paths.srcPath, filename);
 		const destFilename = path.resolve(

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -1,13 +1,11 @@
-const path = require('path');
 const chalk = require('chalk');
 
-const addLocalesOption = require('../util/addLocalesOption');
 const startDev = require('./runScripts/start-dev');
 
 module.exports = {
 	command: 'run',
 	description: 'run the application server',
-	builder: yargs => addLocalesOption(yargs).option('log-static'),
+	builder: yargs => yargs.option('log-static'),
 	handler: argv => {
 		const { NODE_ENV } = process.env;
 		const envString = NODE_ENV || 'development';
@@ -25,7 +23,7 @@ module.exports = {
 		// TODO: check for prerequisites (e.g. up-to-date build/... files)
 		// execute the start-dev script
 		console.log(chalk.blue('Preparing the dev app server...'));
-		startDev(argv.locales);
+		startDev();
 		return;
 	},
 };

--- a/src/commands/runScripts/_app-server.js
+++ b/src/commands/runScripts/_app-server.js
@@ -1,6 +1,7 @@
+const path = require('path');
 const yargs = require('yargs');
 
-const { locales } = require('mwp-config');
+const { locales, paths } = require('mwp-config');
 const openBrowser = require('react-dev-utils/openBrowser');
 const runServer = require(`${process.cwd()}/scripts/app-server`); // TODO: move this script into CLI - currently requires MWP dependency :/
 
@@ -23,20 +24,18 @@ const runServer = require(`${process.cwd()}/scripts/app-server`); // TODO: move 
 const { argv } = yargs.implies('cold-start', 'host');
 
 const getServerAppMap = () => {
-	return Object.keys(argv)
-		.filter(a => locales.includes(a))
-		.reduce((map, localeCode) => {
-			const importPath = argv[localeCode];
-			map[localeCode] = require(importPath).default;
-			return map;
-		}, {});
+	const renderer = require(path.resolve(
+		paths.output.server,
+		'combined',
+		'server-app'
+	)).default;
+
+	return locales.reduce((map, localeCode) => {
+		map[localeCode] = renderer;
+		return map;
+	}, {});
 };
 
-/*
- * The server-starting function. All command line arguments will be treated as
- * <localeCode>=<localeRendererModulePath> unless listed in the `argFilter`
- * above
- */
 function startDevServer() {
 	return runServer(getServerAppMap());
 }

--- a/src/commands/runScripts/_webpack-dev-server.js
+++ b/src/commands/runScripts/_webpack-dev-server.js
@@ -1,16 +1,10 @@
 const fs = require('fs');
 const webpack = require('webpack');
-const yargs = require('yargs');
 const WebpackDevServer = require('webpack-dev-server');
 const { env, webpack: { getBrowserAppConfig } } = require('mwp-config');
 
 // Set up webpack multicompiler - one for each localeCode specified in CLI args
-const localeCodes = yargs
-	.array('locales') // treat locales as array, always
-	.option('locales')
-	.demandOption('locales').argv.locales;
-const configs = localeCodes.map(getBrowserAppConfig);
-const compiler = webpack(configs);
+const compiler = webpack(getBrowserAppConfig('combined'));
 if (process.send) {
 	// we are in a child process. communicate with parent through `process.send`
 	compiler.plugin('done', stats => process.send('done'));
@@ -34,12 +28,9 @@ if (options.https) {
 	options.cert = fs.readFileSync(env.properties.asset_server.crt_file);
 }
 
-if (configs.length === 1) {
-	// WDS won't respect config's publicPath when only 1 config is set
-	// so we need to force it in the `options`
-	options.publicPath = `${env.properties.asset_server
-		.path}/${localeCodes[0]}/`;
-}
+// WDS won't respect config's publicPath when only 1 config is set
+// so we need to force it in the `options`
+options.publicPath = `${env.properties.asset_server.path}/combined/`;
 
 const server = new WebpackDevServer(compiler, options);
 

--- a/src/util/addLocalesOption.js
+++ b/src/util/addLocalesOption.js
@@ -1,4 +1,4 @@
-const { locales } = require('mwp-config');
+const { package: packageConfig, locales } = require('mwp-config');
 
 const supportedLocales =
 	process.env.NODE_ENV === 'production' ? locales : locales.slice(0, 1); // default to top locale in dev

--- a/src/util/addLocalesOption.js
+++ b/src/util/addLocalesOption.js
@@ -1,4 +1,4 @@
-const { package: packageConfig, locales } = require('mwp-config');
+const { locales } = require('mwp-config');
 
 const supportedLocales =
 	process.env.NODE_ENV === 'production' ? locales : locales.slice(0, 1); // default to top locale in dev


### PR DESCRIPTION
**Refactored** `build trn` and `run` will both bundle the app code so that a single bundle supports all languages _in dev_ - this makes for a very large app bundle, but that should be fine in dev and it avoids having to hassle with running the app with `--locales` options. In prod, `build trn` will work as usual.

**New feature** `build [server|browser]` will now write a single bundle supporting all languages if the calling application specifies `config.combineLanguages: true` in its `package.json`.