### PR TITLE
CLI for recording start/stop times and tracking in New Relic Insights

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,1 @@
-save-prefix false
+save-exact true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [6.1]
+
+* **New feature** `time` - track start/stop times and send results to New Relic
+  Insights. [Docs](docs/time.md)
+
 # [6.0]
 
 * **Refactored** `build trn` and `run` will both bundle the app code so that a

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 6.0.$(CI_BUILD_NUMBER)
+VERSION ?= 6.1.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ $ mope <command> [<args>]
 
 - [build](docs/build.md)
 - [run](docs/run.md)
+- [time](docs/time.md)
 - [tx](docs/tx.md)
 
 

--- a/docs/time.md
+++ b/docs/time.md
@@ -1,0 +1,47 @@
+## Time `mope time [start|end|track]`
+
+This utility keeps track of time values, using the file system to persist and
+aggregate data that can be sent to a third party tracker such as New Relic
+Insights
+
+### Env requirements
+
+This command is currently configured to send data to
+[New Relic Insights](https://newrelic.com/insights). In general, you will want
+to supply 2 env variables that enable API authentication
+
+- `NEW_RELIC_ACCOUNT_ID` the integer ID of your application
+- `NEW_RELIC_INSERT_KEY` the _private_ API key from New Relic
+  - Get a new key at https://insights.newrelic.com/accounts/<ACCOUNT_ID>/manage/api_keys
+
+### Commands
+
+#### `[start|end] --attribute <attribute>`
+
+Record the current time as the start or end time for `attribute`.
+
+##### Option: `--attribute`
+
+*Required* for `mope time start` and `mope time end`. The tag/name of the timing
+value to record.
+
+##### Conditions:
+
+- Calling `start` on an attribute that already has a start time will fail.
+- Calling `end` on an attribute that has not been started will fail.
+- Calling `end` on an attribute that has already stopped will fail.
+
+#### `track --type <type> --attributes=<attribute>[,<attribute>...]`
+
+##### Option: `--type`
+
+*Required* for `mope time track`. The event type/name under which to record the
+timing data in the third party tracker. Usually TitleCase.
+
+##### Option: `--attributes`
+
+*Required*. A CSV list of attributes that have been timed with `time [start|end]`.
+
+##### Conditions:
+
+- Calling `track` with an attribute that hasn't _started_ and _ended_ will fail

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "jest": "20.0.4",
     "lint-staged": "4.0.1",
     "mkdirp": "0.5.1",
+    "node-insights": "false1.0.16",
     "prettier": "1.5.2",
     "raw-loader": "0.5.1",
     "react-dev-utils": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "jest": "20.0.4",
     "lint-staged": "4.0.1",
     "mkdirp": "0.5.1",
-    "node-insights": "false1.0.16",
+    "node-insights": "1.0.16",
     "prettier": "1.5.2",
     "raw-loader": "0.5.1",
     "react-dev-utils": "3.0.2",

--- a/src/commands/time.js
+++ b/src/commands/time.js
@@ -1,0 +1,106 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const Insights = require('node-insights');
+
+const TIMER_FILE = path.resolve(os.tmpdir(), '__mwp-timers.json');
+const attribute = {
+	aliases: ['a', 'tag'],
+	demandOption: true,
+	describe: 'The attribute (tag) to time',
+};
+const setCurrentTimes = current =>
+	fs.writeFileSync(TIMER_FILE, JSON.stringify(current));
+const getCurrentTimes = () => {
+	if (!fs.existsSync(TIMER_FILE)) {
+		setCurrentTimes({});
+	}
+	return require(TIMER_FILE);
+};
+
+module.exports = {
+	command: 'time',
+	description: 'record timing data',
+	builder: yargs =>
+		yargs
+			.demandCommand()
+			.command('start', 'record a start time', { attribute }, argv => {
+				const current = getCurrentTimes();
+				if (current[argv.attribute]) {
+					throw new Error(
+						`${argv.attribute} already started at ${argv.attribute
+							.start}`
+					);
+				}
+				current[argv.attribute] = { start: new Date().getTime() };
+				return setCurrentTimes(current);
+			})
+			.command('end', 'record an end time', { attribute }, argv => {
+				const current = getCurrentTimes();
+				const currentTime = current[argv.attribute];
+				if (!currentTime) {
+					throw new Error(`${argv.attribute} not started`);
+				}
+				if (currentTime.end) {
+					throw new Error(
+						`${argv.attribute} already ended at`,
+						new Date(currentTime.end)
+					);
+				}
+				currentTime.end = new Date().getTime();
+				return setCurrentTimes(current);
+			})
+			.command(
+				'track',
+				'upload timing values',
+				{
+					type: {
+						alias: 't',
+						demandOption: true,
+						describe: 'The record type',
+					},
+					attributes: {
+						describe:
+							'the set of attributes to send with this record',
+						type: 'array',
+					},
+					accountId: {
+						alias: 'id',
+						describe: 'The New Relic account ID',
+						demandOption: true,
+						default: process.env.NEW_RELIC_ACCOUNT_ID,
+					},
+					key: {
+						describe: 'The New Relic API insert key',
+						demandOption: true,
+						default: process.env.NEW_RELIC_INSERT_KEY,
+					},
+				},
+				argv => {
+					// create a record based on the requested attributes
+					const current = getCurrentTimes();
+					const record = argv.attributes.reduce((acc, attribute) => {
+						if (!current[attribute]) {
+							throw new Error(`${attribute} not started`);
+						}
+						if (!current[attribute].end) {
+							throw new Error(`${attribute} not finished`);
+						}
+						const currentTime =
+							current[attribute].end - current[attribute].start;
+						acc[attribute] = currentTime / 1000; // report in seconds
+						return acc;
+					}, {});
+
+					// initialize the New Relic Insights API
+					const track = new Insights({
+						insertKey: argv.key,
+						accountId: argv.accountId,
+						defaultEventType: argv.type,
+					});
+					track.add(record);
+					track.finish();
+				}
+			),
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4829,7 +4829,7 @@ node-forge@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.1.tgz#9da611ea08982f4b94206b3beb4cc9665f20c300"
 
-node-insights@false1.0.16:
+node-insights@1.0.16:
   version "1.0.16"
   resolved "https://registry.yarnpkg.com/node-insights/-/node-insights-1.0.16.tgz#59616e303cc4bfb6482689f82bfa49b38e4b4c46"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4477,6 +4477,10 @@ lodash.uniq@^4.5.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
+lodash@^3.6.0:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
+
 log-driver@1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
@@ -4824,6 +4828,13 @@ node-forge@0.6.33:
 node-forge@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.1.tgz#9da611ea08982f4b94206b3beb4cc9665f20c300"
+
+node-insights@false1.0.16:
+  version "1.0.16"
+  resolved "https://registry.yarnpkg.com/node-insights/-/node-insights-1.0.16.tgz#59616e303cc4bfb6482689f82bfa49b38e4b4c46"
+  dependencies:
+    lodash "^3.6.0"
+    request "^2.54.0"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -5980,7 +5991,7 @@ request@2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
-request@^2.34.0, request@^2.72.0, request@^2.79.0, request@^2.81.0:
+request@^2.34.0, request@^2.54.0, request@^2.72.0, request@^2.79.0, request@^2.81.0:
   version "2.83.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
   dependencies:


### PR DESCRIPTION
This CLI will allow us to track build timing data in New Relic Insights over time.

TODO

- [x] Add CHANGELOG info and bump version
- [x] Add README for the new `mope time` command