### PR TITLE
WP 652 new `deploy create` options: --image, --env

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -40,6 +40,11 @@ to their production values:
 
 ### Options
 
+#### `--image`
+
+_Required_. The full image tag source for the deployed image. Usually prefixed with `us.gcr.io/`
+for GCP-hosted images
+
 #### `--incrementWait`
 
 The delay between migration increments, in ms
@@ -59,6 +64,11 @@ beyond the maximum `maxInstances` value.
 
 #### `--targetTraffic`
 _Default: `100`_. The total percentage of traffic to be migrated to the deployment.
+
+#### `--env`
+
+Optional array of environment variable _names_ to read from the deploy environment
+and load into the deployed runtime environment
 
 ## Command: `deploy clean`
 

--- a/src/commands/deployCommands/create.js
+++ b/src/commands/deployCommands/create.js
@@ -24,6 +24,16 @@ module.exports = {
 				demandOption: true,
 				describe: 'The version ID to deploy',
 			},
+			env: {
+				type: 'array',
+				default: [],
+				describe:
+					'Names of environment variables to pass into deployment from deploy env',
+			},
+			image: {
+				demandOption: true,
+				describe: 'The source Docker image tag for the version',
+			},
 			incrementWait: {
 				default: 60000, // 1 minute
 				describe: 'The delay between migration increments',

--- a/src/commands/deployUtils/apiMiddleware.js
+++ b/src/commands/deployUtils/apiMiddleware.js
@@ -45,15 +45,21 @@ const validateEnv = envVariables =>
  * to argv that are consumed by API methods
  */
 const apiMiddleware = argv => {
-	const envVariables = {
-		API_HOST: 'api.meetup.com',
-		COOKIE_ENCRYPT_SECRET,
-		CSRF_SECRET,
-		DEV_SERVER_PORT: '8080',
-		NEW_RELIC_APP_NAME,
-		NEW_RELIC_LICENSE_KEY,
-		PHOTO_SCALER_SALT,
-	};
+	const envVariables = Object.assign(
+		{
+			API_HOST: 'api.meetup.com',
+			COOKIE_ENCRYPT_SECRET,
+			CSRF_SECRET,
+			DEV_SERVER_PORT: '8080',
+			NEW_RELIC_APP_NAME,
+			NEW_RELIC_LICENSE_KEY,
+			PHOTO_SCALER_SALT,
+		},
+		argv.env.reduce((acc, name) => {
+			acc[name] = process.env[name];
+			return acc;
+		}, {})
+	);
 	validateEnv(envVariables);
 
 	const versionIds = Array.apply(null, {

--- a/src/commands/deployUtils/versions.js
+++ b/src/commands/deployUtils/versions.js
@@ -16,6 +16,7 @@ module.exports = (config, { operations, allocations }) => {
 		maxInstances,
 		servicesId,
 		envVariables,
+		image,
 		version,
 		versionIds,
 		indent,
@@ -57,11 +58,7 @@ module.exports = (config, { operations, allocations }) => {
 		Object.assign(
 			{
 				id,
-				deployment: {
-					container: {
-						image: `us.gcr.io/${appsId}/mup-web:${version}`,
-					},
-				},
+				deployment: { container: { image } },
 				envVariables,
 			},
 			baseConfig


### PR DESCRIPTION
In order to use `deploy create` in pro-web, we need to be able to specify the source Docker image tag and pass in arbitrary additional environment variables specified by CLI options