### PR TITLE
add `--minInstances` deploy option

### DIFF
--- a/src/commands/deployCommands/create.js
+++ b/src/commands/deployCommands/create.js
@@ -1,6 +1,10 @@
+const path = require('path');
+const { paths } = require('mwp-config');
 const chalk = require('chalk');
 const runE2E = require('../deployUtils/e2e');
 const apiMiddleware = require('../deployUtils/apiMiddleware');
+
+const baseConfig = require(path.resolve(paths.repoRoot, 'app.json'));
 
 const runE2EWithRetry = id => runE2E(id).catch(() => runE2E(id));
 /*
@@ -36,6 +40,11 @@ module.exports = {
 				default: 100,
 				describe:
 					'The percentage of traffic to migrate in each increment',
+			},
+			minInstances: {
+				default:
+					(baseConfig.automaticScaling || {}).minTotalInstances || 16,
+				describe: 'Minimum instances per deployment',
 			},
 			maxInstances: {
 				default: 196,

--- a/src/commands/deployUtils/versions.js
+++ b/src/commands/deployUtils/versions.js
@@ -13,6 +13,7 @@ module.exports = (config, { operations, allocations }) => {
 		auth,
 		appsId,
 		deployCount,
+		minInstances,
 		maxInstances,
 		servicesId,
 		envVariables,
@@ -59,6 +60,12 @@ module.exports = (config, { operations, allocations }) => {
 				id,
 				deployment: { container: { image } },
 				envVariables,
+				automaticScaling: Object.assign(
+					baseConfig.automaticScaling || {},
+					{
+						minTotalInstances: minInstances,
+					}
+				),
 			},
 			baseConfig
 		);


### PR DESCRIPTION
This will allow the `deploy create` command to be configurable with the minimum instances, which will be used by the canary build to perform a very small (and hopefully fast) deployment of a single instance that will hand e2e tests