### PR TITLE
Update start-dev.js; check for stats

### DIFF
--- a/src/commands/runScripts/start-dev.js
+++ b/src/commands/runScripts/start-dev.js
@@ -34,27 +34,29 @@ const getCompileLogger = type => (err, stats) => {
 		process.exit(1);
 	}
 
-	const info = stats.toJson();
+	if (stats) {
+		const info = stats.toJson();
+		
+		// handle compilation errors (missing modules, syntax errors, etc)
+		if (stats.hasErrors()) {
+			info.errors
+				.map(x => x.split('\n'))
+				.map(errorLogLines)
+				.map(lines => lines.join('\n   '))
+				.map(replaceCwd)
+				.map(x => chalk.red(x))
+				.forEach(x => log(x));
 
-	// handle compilation errors (missing modules, syntax errors, etc)
-	if (stats.hasErrors()) {
-		info.errors
-			.map(x => x.split('\n'))
-			.map(errorLogLines)
-			.map(lines => lines.join('\n   '))
-			.map(replaceCwd)
-			.map(x => chalk.red(x))
-			.forEach(x => log(x));
-
-		process.exit(1);
+			process.exit(1);
+		}
+		
+		if (stats.hasWarnings()) {
+			console.log(
+				chalk.red('webpack compilation warning:')
+			);
+			console.info(info.warnings);
+		}
 	}
-
-	if (stats.hasWarnings()) {
-		console.log(
-			chalk.red('webpack compilation warning:')
-		);
-		console.info(info.warnings);
-	};
 
 	const message = ready[type]
 		? chalk.blue(`${type} updated`)


### PR DESCRIPTION
When I tested with the beta package this wasn't happening, but now in  mup-web seems like stats might be undefined, so adding a check:

```/Users/sadaf/git_repo/mup-web/node_modules/mwp-cli/src/commands/runScripts/start-dev.js:37
	const info = stats.toJson();
	                   ^

TypeError: Cannot read property 'toJson' of undefined
    at /Users/sadaf/git_repo/mup-web/node_modules/mwp-cli/src/commands/runScripts/start-dev.js:37:21
    at ChildProcess.wdsProcess.on.message (/Users/sadaf/git_repo/mup-web/node_modules/mwp-cli/src/commands/runScripts/start-dev.js:113:3)
    at ChildProcess.emit (events.js:180:13)
    at emit (internal/child_process.js:783:12)```