### PR TITLE
Investigate webpack source map leak

### DIFF
--- a/src/commands/buildCommands/configs/browserAppConfig.js
+++ b/src/commands/buildCommands/configs/browserAppConfig.js
@@ -67,7 +67,7 @@ function getConfig(localeCode) {
 			publicPath
 		},
 
-		devtool: 'cheap-module-source-map', // similar speed to 'eval', but with proper source maps
+		devtool: env.properties.isProd ? 'hidden-source-map' : 'cheap-module-source-map', // similar speed to 'eval', but with proper source maps
 
 		module: {
 			rules: [

--- a/src/commands/buildCommands/configs/serverAppConfig.js
+++ b/src/commands/buildCommands/configs/serverAppConfig.js
@@ -41,7 +41,7 @@ function getConfig(localeCode) {
 			publicPath
 		},
 
-		devtool: 'eval',
+		devtool: env.properties.isProd ? 'hidden-source-map' : 'eval',
 
 		module: {
 			rules: [


### PR DESCRIPTION
We received a message in #groups-product-watch from ComX saying that someone shared a link that our source maps are available unobfuscated.

Here's a picture to confirm the issue:

![image](https://user-images.githubusercontent.com/16173708/40932960-0c631fda-67fe-11e8-8542-beec4b5a7584.png)

I'm under the impression that we still want source maps to track errors through the stack. In the case that we do, we can use the `hidden-source-map` tool in webpack to expose just the file names.

I'm pretty sure this is where the error is coming from, but please correct me if I'm wrong! 🙏 