### PR TITLE
Process main.scss with PostCSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [8.2]
+
+* **BREAKING CHANGE** `mope build` will run any files matching `main.scss` through PostCSS. Inline loaders should no longer be used on `main.scss`. Expect warnings from PostCSS until we remove unneeded browser prefixes
+
 # [7.2]
 
 * **New feature** `mope build status` check the status of a Travis build, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# [8.2]
+# [8.0]
 
 * **BREAKING CHANGE** `mope build` will run any files matching `main.scss` through PostCSS. Inline loaders should no longer be used on `main.scss`. Expect warnings from PostCSS until we remove unneeded browser prefixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * **BREAKING CHANGE** `mope build` will run any files matching `main.scss` through PostCSS. Inline loaders should no longer be used on `main.scss`. Expect warnings from PostCSS until we remove unneeded browser prefixes
 
+For example in `cssLinks.js`,
+this: `const baseCSSHref = require('file-loader?name=[name].[hash:7].css!extract-loader!css-loader!sass-loader!../assets/scss/main.scss');`
+becomes this: `const baseCSSHref = require('../assets/scss/main.scss');`
+
 # [7.2]
 
 * **New feature** `mope build status` check the status of a Travis build, and

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 8.2.$(CI_BUILD_NUMBER)
+VERSION ?= 8.0.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 7.2.$(CI_BUILD_NUMBER)
+VERSION ?= 8.2.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/src/commands/buildCommands/configs/browserAppConfig.js
+++ b/src/commands/buildCommands/configs/browserAppConfig.js
@@ -73,6 +73,7 @@ function getConfig(localeCode) {
 			rules: [
 				rules.file,
 				rules.scssModule,
+				rules.scss,
 				rules.css,
 				rules.js.browser,
 				rules.raw

--- a/src/commands/buildCommands/configs/browserAppConfig.js
+++ b/src/commands/buildCommands/configs/browserAppConfig.js
@@ -73,7 +73,7 @@ function getConfig(localeCode) {
 			rules: [
 				rules.file,
 				rules.scssModule,
-				rules.scss,
+				rules.baseScss,
 				rules.css,
 				rules.js.browser,
 				rules.raw

--- a/src/commands/buildCommands/configs/postCssLoaderConfig.js
+++ b/src/commands/buildCommands/configs/postCssLoaderConfig.js
@@ -1,0 +1,21 @@
+const customProperties = require('swarm-constants/dist/js/customProperties.js').customProperties;
+
+module.exports = {
+    loader: 'postcss-loader',
+    options: {
+        ident: 'postcss',
+        plugins: loader => [
+            require('postcss-cssnext')({
+                browsers: ['last 2 versions', 'not ie <= 10'],
+                features: {
+                    customProperties: false,
+                    colorFunction: false,
+                },
+            }),
+            require('postcss-css-variables')({
+                preserve: true,
+                variables: customProperties,
+            })
+        ]
+    }
+};

--- a/src/commands/buildCommands/configs/rules.js
+++ b/src/commands/buildCommands/configs/rules.js
@@ -24,7 +24,7 @@ module.exports = {
 			'sass-loader'
 		]
 	},
-	scss: {
+	baseScss: {
 		test: /main\.scss$/,
 		include: [paths.srcPath],
 		use: [

--- a/src/commands/buildCommands/configs/rules.js
+++ b/src/commands/buildCommands/configs/rules.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const { babel, env, paths } = require('mwp-config');
-const customProperties = require('swarm-constants/dist/js/customProperties.js').customProperties;
+const postCssLoaderConfig = require('./postCssLoaderConfig.js');
 
 /**
  * @see https://webpack.js.org/configuration/module/#module-rules
@@ -20,25 +20,23 @@ module.exports = {
 					minimize: true
 				}
 			},
+			postCssLoaderConfig,
+			'sass-loader'
+		]
+	},
+	scss: {
+		test: /main\.scss$/,
+		include: [paths.srcPath],
+		use: [
 			{
-				loader: 'postcss-loader',
+				loader: 'file-loader',
 				options: {
-					ident: 'postcss',
-					plugins: loader => [
-						require('postcss-cssnext')({
-							browsers: ['last 2 versions', 'not ie <= 10'],
-							features: {
-								customProperties: false,
-								colorFunction: false,
-							},
-						}),
-						require('postcss-css-variables')({
-							preserve: true,
-							variables: customProperties,
-						})
-					]
+					name: '[name].[hash:7].css'
 				}
 			},
+			'extract-loader',
+			'css-loader',
+			postCssLoaderConfig,
 			'sass-loader'
 		]
 	},

--- a/src/commands/buildCommands/configs/serverAppConfig.js
+++ b/src/commands/buildCommands/configs/serverAppConfig.js
@@ -47,6 +47,7 @@ function getConfig(localeCode) {
 			rules: [
 				rules.file,
 				rules.scssModule,
+				rules.scss,
 				rules.css,
 				rules.js.server,
 				rules.raw

--- a/src/commands/buildCommands/configs/serverAppConfig.js
+++ b/src/commands/buildCommands/configs/serverAppConfig.js
@@ -47,7 +47,7 @@ function getConfig(localeCode) {
 			rules: [
 				rules.file,
 				rules.scssModule,
-				rules.scss,
+				rules.baseScss,
 				rules.css,
 				rules.js.server,
 				rules.raw


### PR DESCRIPTION
This is a step we need to take to remove [Bourbon](https://www.bourbon.io/) as a dependency and make our styles less dependent on SASS.

You can test this change by removing `main.scss`'s inline Webpack loader from `cssLinks.js`
This: `const baseCSSHref = require('file-loader?name=[name].[hash:7].css!extract-loader!css-loader!sass-loader!../assets/scss/main.scss');`
Becomes this: `const baseCSSHref = require('../assets/scss/main.scss');`

I've already filed three follow-up tickets that would allow us to remove Bourbon:
[Remove Bourbon from swarm-sasstools](https://meetup.atlassian.net/browse/SST-12)
[Remove Bourbon from mup-web](https://meetup.atlassian.net/browse/SDS-694)
[Remove Bourbon from pro-web](https://meetup.atlassian.net/browse/SDS-695)