### PR TITLE
Upgrade postcss variable plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "mkdirp": "0.5.1",
     "node-insights": "1.0.16",
     "node-sass": "4.9.0",
-    "postcss-css-variables": "0.8.1",
+    "postcss-css-variables": "0.9.0",
     "postcss-cssnext": "3.1.0",
     "postcss-loader": "2.1.4",
     "prettier": "1.12.1",

--- a/src/commands/buildCommands/configs/postCssLoaderConfig.js
+++ b/src/commands/buildCommands/configs/postCssLoaderConfig.js
@@ -15,6 +15,7 @@ module.exports = {
             require('postcss-css-variables')({
                 preserve: true,
                 variables: customProperties,
+                preserveInjectedVariables: false,
             })
         ]
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6856,9 +6856,9 @@ postcss-css-variables@0.8.0:
     extend "^3.0.1"
     postcss "^6.0.8"
 
-postcss-css-variables@0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/postcss-css-variables/-/postcss-css-variables-0.8.1.tgz#a52e5ef1a2eb633a8a4f5fc434d6d85d40fe7310"
+postcss-css-variables@0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/postcss-css-variables/-/postcss-css-variables-0.9.0.tgz#dc442742b460949fa0a53f5a7c91b0115319cf7f"
   dependencies:
     escape-string-regexp "^1.0.3"
     extend "^3.0.1"


### PR DESCRIPTION
This version of [postcss-css-variables](https://github.com/MadLittleMods/postcss-css-variables) adds an option called `preserveInjectedVariables`. When set to false, custom properties don't get injected with each style module. See example output below from `insetParagraph.module.scss` - a module used on the about page

Before `preserveInjectedVariables: false`:
<img width="1237" alt="screen shot 2018-07-02 at 11 36 21 am" src="https://user-images.githubusercontent.com/2313998/42173833-514fce3a-7dee-11e8-97c1-f17791e9d3ba.png">

After `preserveInjectedVariables: false`:
<img width="1233" alt="screen shot 2018-07-02 at 11 37 18 am" src="https://user-images.githubusercontent.com/2313998/42173864-6eb3c616-7dee-11e8-84b9-412356cb2a90.png">
