### PR TITLE
add picker locale modules to `build trn` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
     as `datepickerOptions.locale` params to MWC `CalendarComponent` in order to
     localize the date picker.
 
+    Import syntax aligns other TRN imports
+
+    ```jsx
+    import pickerLocale from 'trns/date/pickerLocale';
+    ...
+    <CalendarComponent datepickerOptions={{ locale: pickerLocale }} />
+    ```
+
 # [8.0]
 
 *   **BREAKING CHANGE** `mope deploy create` will no longer migrate traffic to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@
     as `datepickerOptions.locale` params to MWC `CalendarComponent` in order to
     localize the date picker.
 
-    Import syntax aligns other TRN imports
+    Import syntax aligns other TRN imports - be sure to key into the `pickerLocale`
+    map using the appropriate `localeCode`
 
     ```jsx
     import pickerLocale from 'trns/date/pickerLocale';
     ...
-    <CalendarComponent datepickerOptions={{ locale: pickerLocale }} />
+    <CalendarComponent datepickerOptions={{ locale: pickerLocale[localeCode] }} />
     ```
 
 # [8.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [8.1]
+
+*   **New feature** `mope build trn` will now also write 'pickerLocale' modules
+    that can be imported just like other TRN modules. The values can be passed
+    as `datepickerOptions.locale` params to MWC `CalendarComponent` in order to
+    localize the date picker.
+
 # [8.0]
 
 *   **BREAKING CHANGE** `mope deploy create` will no longer migrate traffic to the

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 8.0.$(CI_BUILD_NUMBER)
+VERSION ?= 8.1.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/src/commands/buildCommands/trn.js
+++ b/src/commands/buildCommands/trn.js
@@ -36,6 +36,7 @@ const writeTrnModules = messagesByLocale => ({ filename, msgids }) => {
 		return acc;
 	}, {});
 
+	// in dev, we want to build a single module containing all locales
 	if (
 		packageConfig.combineLanguages ||
 		process.env.NODE_ENV !== 'production'
@@ -49,7 +50,7 @@ const writeTrnModules = messagesByLocale => ({ filename, msgids }) => {
 		);
 		return writeTrnFile(destFilename, trns);
 	}
-	// one trn file per supported locale
+	// otherwise, write a single module-per-locale
 	return Promise.all(
 		locales.map(localeCode => {
 			const langTrns = { [localeCode]: trns[localeCode] };
@@ -97,6 +98,7 @@ const PICKER_LOCALES = {
 	'tr-TR': fpLocale('tr'),
 };
 const buildDateLocales = () => {
+	// in dev, we want to build a single module containing all locales
 	if (
 		packageConfig.combineLanguages ||
 		process.env.NODE_ENV !== 'production'
@@ -111,6 +113,7 @@ const buildDateLocales = () => {
 		return writeFile(destFilename, JSON.stringify(PICKER_LOCALES));
 	}
 
+	// otherwise, write a single module-per-locale
 	return Promise.all(
 		locales.map(localeCode => {
 			const destFilename = path.resolve(

--- a/src/commands/buildCommands/trn.js
+++ b/src/commands/buildCommands/trn.js
@@ -74,7 +74,7 @@ const componentTrnDefinitions$ = localTrns$.map(trnsFromFile => ({
 }));
 
 // Function for importing Flatpickr (fp) locale data for a particular 2-character
-// language code code
+// language code code - see https://flatpickr.js.org/localization/
 const fpLocale = lang =>
 	require(require.resolve(`flatpickr/dist/l10n/${lang}`, {
 		paths: [paths.repoRoot],

--- a/src/commands/buildCommands/trn.js
+++ b/src/commands/buildCommands/trn.js
@@ -72,6 +72,62 @@ const componentTrnDefinitions$ = localTrns$.map(trnsFromFile => ({
 	msgids: trnsFromFile.map(({ id }) => id),
 }));
 
+// Function for importing Flatpickr (fp) locale data for a particular 2-character
+// language code code
+const fpLocale = lang =>
+	require(require.resolve(`flatpickr/dist/l10n/${lang}`, {
+		paths: [paths.repoRoot],
+	}))[lang];
+
+const PICKER_LOCALES = {
+	'en-US': undefined, // default
+	'en-AU': undefined, // default
+	'de-DE': fpLocale('de'),
+	es: fpLocale('es'),
+	'es-ES': fpLocale('es'),
+	'fr-FR': fpLocale('fr'),
+	'it-IT': fpLocale('it'),
+	'ja-JP': fpLocale('ja'),
+	'ko-KR': fpLocale('ko'),
+	'nl-NL': fpLocale('nl'),
+	'pt-BR': fpLocale('pt'),
+	'pl-PL': fpLocale('pl'),
+	'ru-RU': fpLocale('ru'),
+	'th-TH': fpLocale('th'),
+	'tr-TR': fpLocale('tr'),
+};
+const buildDateLocales = () => {
+	if (
+		packageConfig.combineLanguages ||
+		process.env.NODE_ENV !== 'production'
+	) {
+		const destFilename = path.resolve(
+			MODULES_PATH,
+			'combined',
+			'date',
+			'pickerLocale.json'
+		);
+		mkdirp.sync(path.dirname(destFilename));
+		return writeFile(destFilename, JSON.stringify(PICKER_LOCALES));
+	}
+
+	return Promise.all(
+		locales.map(localeCode => {
+			const destFilename = path.resolve(
+				MODULES_PATH,
+				localeCode,
+				'date',
+				'pickerLocale.json'
+			);
+			mkdirp.sync(path.dirname(destFilename));
+			return writeFile(
+				destFilename,
+				JSON.stringify({ [localeCode]: PICKER_LOCALES[localeCode] })
+			).then(() => console.log('Wrote', destFilename));
+		})
+	);
+};
+
 /**
  * Write JSON modules for each component that defines TRN messages. Missing
  * translations will result in an empty JSON object
@@ -89,21 +145,26 @@ function main() {
 	console.log('Cleaning TRN modules directory');
 	child_process.execSync(`rm -rf ${MODULES_PATH}`);
 
-	console.log('Transpiling TRN source to JSON...');
-	buildTrnModules().toPromise().then(
-		trnDefs => {
-			console.log(
-				chalk.green(
-					`Wrote TRN modules for ${trnDefs.length} components`
-				)
-			);
-		},
-		err => {
-			console.error(chalk.red('TRN module build failed'));
-			console.error(chalk.red(err.toString()));
-			process.exit(1);
-		}
-	);
+	console.log('Writing locale data modules for datepicker');
+	buildDateLocales()
+		.then(() => {
+			console.log('Transpiling TRN source to JSON...');
+			return buildTrnModules().toPromise();
+		})
+		.then(
+			trnDefs => {
+				console.log(
+					chalk.green(
+						`Wrote TRN modules for ${trnDefs.length} components`
+					)
+				);
+			},
+			err => {
+				console.error(chalk.red('TRN module build failed'));
+				console.error(chalk.red(err.toString()));
+				process.exit(1);
+			}
+		);
 }
 
 module.exports = {


### PR DESCRIPTION
This PR updates `mope build trn` to write language-specific datepicker `locale` definition modules. These modules are similar to transifex translation data, but provide flatpickr `locale` data that can be passed into MWC `CalendarComponent`

**Followup** define a standard `<DatePicker />` component in mup-web that will automatically localize the datepicker based on the current user's `requestLanguage`