### PR TITLE
add error handling function to `tx push`

### DIFF
--- a/src/commands/txCommands/push.js
+++ b/src/commands/txCommands/push.js
@@ -92,7 +92,10 @@ module.exports = {
 		console.log(chalk.blue('pushing content to transifex'));
 		pushContent$.subscribe(
 			null,
-			(error) => console.error(`encountered error during push: ${error}`),
+			(error) => {
+				console.error(`encountered error during push: ${error}`);
+				process.exit(1);
+			},
 			() => console.log(`content pushed`)
 		);
 	},

--- a/src/commands/txCommands/push.js
+++ b/src/commands/txCommands/push.js
@@ -90,6 +90,10 @@ module.exports = {
 		checkNotMaster$.subscribe();
 
 		console.log(chalk.blue('pushing content to transifex'));
-		pushContent$.subscribe(null, null, () => console.log(`content pushed`));
+		pushContent$.subscribe(
+			null,
+			(error) => console.error(`encountered error during push: ${error}`),
+			() => console.log(`content pushed`)
+		);
 	},
 };

--- a/src/commands/txCommands/util/pushTxAllTranslations.js
+++ b/src/commands/txCommands/util/pushTxAllTranslations.js
@@ -7,7 +7,10 @@ const pushTxAllTranslations = () => {
   txlib.updateAllTranslationsResource$
     .subscribe(
         null,
-        (error) => console.error(`encountered error during upload: ${error}`),
+        (error) => {
+            console.error(`encountered error during upload: ${error}`);
+            process.exit(1);
+        },
         () => console.log('done')
     );
 };

--- a/src/commands/txCommands/util/pushTxMaster.js
+++ b/src/commands/txCommands/util/pushTxMaster.js
@@ -11,7 +11,10 @@ const pushTxMaster = () => {
 		.concat(txlib.updateMasterContent$, txlib.updateTranslations$) // update master content before pushing translations
 		.subscribe(
 			null,
-			(error) => console.error(`encountered error during upload: ${error}`),
+			(error) => {
+				console.error(`encountered error during upload: ${error}`);
+				process.exit(1);
+			},
 			() => console.log('done')
 		);
 };


### PR DESCRIPTION
Jira ticket here:
https://meetup.atlassian.net/browse/WP-921

This problem has 2 parts:
1. Branches in PR: malformed trns silently fail the mope tx push command, which is called on PR branches
2. Branches merged to master: malformed trns throw an error but still succeeds the travis job that pushes trn keys

Because of both of these bugs, translations were broken for a few weeks because errors were being thrown, halting the translation upload process, but we were unaware this was happening because all checks and travis builds were succeeding.

What this PR does:
- Make sure errors are handled in `mope tx push`
- exit the process if it fails to push translations - if it's going to fail it should fail loudly otherwise we'll never know until it's too late. 

tested this with this mup-web PR:
https://github.com/meetup/mup-web/pull/5077 - build fails, which is what we want.