### PR TITLE
WP 951 deploy stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [8.3]
+
+*   **New feature** `mope deploy stop --versionId=...` to stop a specific deployed
+    version in the cloud - this will free resources for deployments that are not
+    expected to receive traffic
+
 # [8.2]
 
 *   **New feature** `--force` flag on `mope deploy create` will redeploy the build

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 8.2.$(CI_BUILD_NUMBER)
+VERSION ?= 8.3.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/README.md
+++ b/README.md
@@ -13,16 +13,18 @@ $ mope <command> [<args>]
 
 ## Commands
 
-- [build](docs/build.md)
-- [run](docs/run.md)
-- [time](docs/time.md)
-- [tx](docs/tx.md)
-
+*   [build](docs/build.md)
+*   [deploy](docs/deploy.md)
+*   [run](docs/run.md)
+*   [time](docs/time.md)
+*   [tx](docs/tx.md)
 
 ## Developing
+
 The mwp-cli executable (mope) is defined in /bin/mope.js - you can execute it directly without installing the `mwp-cli` package. In development, this means that you can test the CLI from your application directory by running node path/to/mwp-cli/bin/mope.js
 
 For example on running `mwp-cli` from `mup-web`
-1. Checkout `mwp-cli` and a `*-web` repo in this example `mup-web`
-2. Go to `mup-web` repo folder
-3. From `mup-web` run `node ../mwp-cli/bin/mope.js COMMAND` (e.g. `node ../mwp-cli/bin/mope.js tx pullAll` which will pull all trns down for the mup-web transifex project)
+
+1.  Checkout `mwp-cli` and a `*-web` repo in this example `mup-web`
+2.  Go to `mup-web` repo folder
+3.  From `mup-web` run `node ../mwp-cli/bin/mope.js COMMAND` (e.g. `node ../mwp-cli/bin/mope.js tx pullAll` which will pull all trns down for the mup-web transifex project)

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -27,8 +27,9 @@ module.exports = {
 				force: {
 					type: 'boolean',
 					default: false,
-					describe: 'forces deploy without checking if deployment already exists'
-				}
+					describe:
+						'forces deploy without checking if deployment already exists',
+				},
 			})
 			.commandDir('deployCommands')
 			.demandCommand(),

--- a/src/commands/deployCommands/delete.js
+++ b/src/commands/deployCommands/delete.js
@@ -1,6 +1,3 @@
-const path = require('path');
-const { paths } = require('mwp-config');
-const chalk = require('chalk');
 const apiMiddleware = require('../deployUtils/apiMiddleware');
 
 const { CI_BUILD_NUMBER } = process.env;

--- a/src/commands/deployCommands/stop.js
+++ b/src/commands/deployCommands/stop.js
@@ -1,0 +1,24 @@
+const apiMiddleware = require('../deployUtils/apiMiddleware');
+
+const { CI_BUILD_NUMBER } = process.env;
+
+module.exports = {
+	command: 'stop',
+	description: 'stop the specified version',
+	builder: yargs =>
+		yargs.options({
+			versionId: {
+				default: CI_BUILD_NUMBER, // defaults to stopping 'current' deployment
+				demandOption: true,
+				describe: 'The version ID to stop',
+			},
+		}),
+	middlewares: [apiMiddleware],
+	handler: argv => {
+		return argv
+			.getDeployApi()
+			.then(api => api.versions.stop([{ id: argv.versionId }]))
+			.catch(err => console.error(err));
+		// should we wait to retry if version is currently still deploying?
+	},
+};

--- a/src/commands/deployCommands/stop.js
+++ b/src/commands/deployCommands/stop.js
@@ -17,7 +17,7 @@ module.exports = {
 	handler: argv => {
 		return argv
 			.getDeployApi()
-			.then(api => api.versions.stop([{ id: argv.versionId }]))
+			.then(api => api.versions.stop(argv.versionIds.map(id => ({ id }))))
 			.catch(err => console.error(err));
 		// should we wait to retry if version is currently still deploying?
 	},

--- a/src/commands/deployCommands/stop.js
+++ b/src/commands/deployCommands/stop.js
@@ -2,6 +2,15 @@ const apiMiddleware = require('../deployUtils/apiMiddleware');
 
 const { CI_BUILD_NUMBER } = process.env;
 
+/**
+ * This command will make a simple attempt to STOP the specified version. If
+ * another operation is already being performed on the version (e.g. it is still
+ * in the process of deploying), it will fail with an error message but will not
+ * return a non-zero exit code.
+ *
+ * Use this command to free up the instance resources being consumed by a deployment
+ * that has been set to SERVING status
+ */
 module.exports = {
 	command: 'stop',
 	description: 'stop the specified version',
@@ -14,11 +23,9 @@ module.exports = {
 			},
 		}),
 	middlewares: [apiMiddleware],
-	handler: argv => {
-		return argv
+	handler: argv =>
+		argv
 			.getDeployApi()
 			.then(api => api.versions.stop(argv.versionIds.map(id => ({ id }))))
-			.catch(err => console.error(err));
-		// should we wait to retry if version is currently still deploying?
-	},
+			.catch(err => console.error(err)),
 };


### PR DESCRIPTION
`mope deploy stop` to stop a particular deployment (version) from serving in GAE

- frees CPU/instance resources