### PR TITLE
update ajv

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@alrra/travis-scripts": "3.0.1",
     "@google-cloud/storage": "1.6.0",
     "@octokit/rest": "15.9.5",
-    "ajv": "5",
+    "ajv": "6.6.2",
     "babel-core": "6.26.3",
     "babel-loader": "7.1.4",
     "babel-plugin-react-intl": "2.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -406,7 +406,16 @@ ajv-keywords@^3.0.0, ajv-keywords@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
 
-ajv@5, ajv@^5.1.0, ajv@^5.2.3, ajv@^5.3.0:
+ajv@6.6.2:
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.6.2.tgz#caceccf474bf3fc3ce3b147443711a24063cc30d"
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^5.1.0, ajv@^5.2.3, ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   dependencies:
@@ -10020,7 +10029,7 @@ update-notifier@^2.3.0:
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
 
-uri-js@^4.2.1:
+uri-js@^4.2.1, uri-js@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
   dependencies:


### PR DESCRIPTION
updating ajv to fix yarn conflicts. pair with @sadafie 

yarn check errors
```
jackie-mbp@jackie-mbp ~/Development/mup-web (update-formik) $ yarn check
yarn check v1.9.4
warning gitbook-plugin-github@2.0.0: The engine "gitbook" appears to be invalid.
error "ajv" is wrong version: expected "5.5.2", got "6.5.3"
```

why ajv
```
jackie-mbp@jackie-mbp ~/Development/mup-web (update-formik) $ yarn why ajv
yarn why v1.9.4
[1/4] 🤔  Why do we have the module "ajv"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "ajv@5.5.2"
info Has been hoisted to "ajv"
info Reasons this module exists
   - Hoisted from "mwp-cli#ajv"
   - Hoisted from "mwp-app-server#mwp-api-proxy-plugin#ajv"
   - Hoisted from "request#har-validator#ajv"
   - Hoisted from "mwp-cli#node-sass#request#har-validator#ajv"
   - Hoisted from "mwp-app-server#mwp-app-route-plugin#ldclient-node#request#har-validator#ajv"
   - Hoisted from "mwp-cli#googleapis#google-auth-library#request#har-validator#ajv"
info Disk size without dependencies: "1.07MB"
info Disk size with unique dependencies: "1.25MB"
info Disk size with transitive dependencies: "1.25MB"
info Number of shared dependencies: 4
=> Found "schema-utils#ajv@6.5.3"
info This module exists because "schema-utils" depends on it.
=> Found "eslint#ajv@6.6.1"
info This module exists because "eslint" depends on it.
info Disk size without dependencies: "1.09MB"
info Disk size with unique dependencies: "1.98MB"
info Disk size with transitive dependencies: "2.01MB"
info Number of shared dependencies: 5
=> Found "file-loader#ajv@6.5.3"
info Reasons this module exists
   - "file-loader#schema-utils" depends on it
   - Hoisted from "file-loader#schema-utils#ajv"
=> Found "webpack#ajv@6.5.3"
info Reasons this module exists
   - "mwp-cli#webpack" depends on it
   - Hoisted from "mwp-cli#webpack#schema-utils#ajv"
=> Found "table#ajv@6.6.1"
info This module exists because "eslint#table" depends on it.
info Disk size without dependencies: "1.09MB"
info Disk size with unique dependencies: "1.98MB"
info Disk size with transitive dependencies: "2.01MB"
info Number of shared dependencies: 5
=> Found "stylelint#ajv@6.5.3"
info Reasons this module exists
   - "mwp-config#stylelint#table" depends on it
   - Hoisted from "mwp-config#stylelint#table#ajv"
=> Found "style-loader#ajv@6.5.3"
info Reasons this module exists
   - "mwp-cli#style-loader#schema-utils" depends on it
   - Hoisted from "mwp-cli#style-loader#schema-utils#ajv"
=> Found "uglifyjs-webpack-plugin#ajv@6.5.3"
info Reasons this module exists
   - "mwp-cli#uglifyjs-webpack-plugin#schema-utils" depends on it
   - Hoisted from "mwp-cli#uglifyjs-webpack-plugin#schema-utils#ajv"
✨  Done in 2.22s.
```
