### PR TITLE
Changes flatpickr filepath require

### DIFF
--- a/src/commands/buildCommands/trn.js
+++ b/src/commands/buildCommands/trn.js
@@ -78,7 +78,7 @@ const componentTrnDefinitions$ = localTrns$.map(trnsFromFile => ({
 const fpLocale = lang =>
 	require(require.resolve(`flatpickr/dist/l10n/${lang}`, {
 		paths: [paths.repoRoot],
-	}))[lang];
+	}));
 
 const PICKER_LOCALES = {
 	'en-US': undefined, // default


### PR DESCRIPTION
The file structure of flatpickr has changed, leading to unlocalized date pickers in mup-web. This change should require the new correct path.