### PR TITLE
OS-90: Date picker calendar not localized

### DIFF
--- a/src/commands/buildCommands/trn.js
+++ b/src/commands/buildCommands/trn.js
@@ -1,17 +1,17 @@
-const { promisify } = require("util");
-const child_process = require("child_process");
-const fs = require("fs");
-const path = require("path");
-const chalk = require("chalk");
-const mkdirp = require("mkdirp");
+const { promisify } = require('util');
+const child_process = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const chalk = require('chalk');
+const mkdirp = require('mkdirp');
 
-const { paths, locales, package: packageConfig } = require("mwp-config");
+const { paths, locales, package: packageConfig } = require('mwp-config');
 const {
 	allLocalPoTrnsWithFallbacks$,
 	localTrns$
-} = require("../txCommands/util");
+} = require('../txCommands/util');
 
-const MODULES_PATH = path.resolve(paths.repoRoot, "src/trns/modules/");
+const MODULES_PATH = path.resolve(paths.repoRoot, 'src/trns/modules/');
 
 const writeFile = promisify(fs.writeFile);
 
@@ -39,13 +39,13 @@ const writeTrnModules = messagesByLocale => ({ filename, msgids }) => {
 	// in dev, we want to build a single module containing all locales
 	if (
 		packageConfig.combineLanguages ||
-		process.env.NODE_ENV !== "production"
+		process.env.NODE_ENV !== 'production'
 	) {
 		// one trn file, all trns
 		const relPath = path.relative(paths.srcPath, filename);
 		const destFilename = path.resolve(
 			MODULES_PATH,
-			"combined",
+			'combined',
 			`${relPath}.json`
 		);
 		return writeTrnFile(destFilename, trns);
@@ -68,7 +68,7 @@ const writeTrnModules = messagesByLocale => ({ filename, msgids }) => {
 const componentTrnDefinitions$ = localTrns$.map(trnsFromFile => ({
 	filename: path.resolve(
 		paths.repoRoot,
-		trnsFromFile[0].file.replace(/\.jsx?$/, "")
+		trnsFromFile[0].file.replace(/\.jsx?$/, '')
 	),
 	msgids: trnsFromFile.map(({ id }) => id)
 }));
@@ -88,33 +88,33 @@ const fpLocale = lang => {
 };
 
 const PICKER_LOCALES = {
-	"en-US": undefined, // default
-	"en-AU": undefined, // default
-	"de-DE": fpLocale("de"),
-	es: fpLocale("es"),
-	"es-ES": fpLocale("es"),
-	"fr-FR": fpLocale("fr"),
-	"it-IT": fpLocale("it"),
-	"ja-JP": fpLocale("ja"),
-	"ko-KR": fpLocale("ko"),
-	"nl-NL": fpLocale("nl"),
-	"pt-BR": fpLocale("pt"),
-	"pl-PL": fpLocale("pl"),
-	"ru-RU": fpLocale("ru"),
-	"th-TH": fpLocale("th"),
-	"tr-TR": fpLocale("tr")
+	'en-US': undefined, // default
+	'en-AU': undefined, // default
+	'de-DE': fpLocale('de'),
+	es: fpLocale('es'),
+	'es-ES': fpLocale('es'),
+	'fr-FR': fpLocale('fr'),
+	'it-IT': fpLocale('it'),
+	'ja-JP': fpLocale('ja'),
+	'ko-KR': fpLocale('ko'),
+	'nl-NL': fpLocale('nl'),
+	'pt-BR': fpLocale('pt'),
+	'pl-PL': fpLocale('pl'),
+	'ru-RU': fpLocale('ru'),
+	'th-TH': fpLocale('th'),
+	'tr-TR': fpLocale('tr')
 };
 const buildDateLocales = () => {
 	// in dev, we want to build a single module containing all locales
 	if (
 		packageConfig.combineLanguages ||
-		process.env.NODE_ENV !== "production"
+		process.env.NODE_ENV !== 'production'
 	) {
 		const destFilename = path.resolve(
 			MODULES_PATH,
-			"combined",
-			"date",
-			"pickerLocale.json"
+			'combined',
+			'date',
+			'pickerLocale.json'
 		);
 		mkdirp.sync(path.dirname(destFilename));
 		return writeFile(destFilename, JSON.stringify(PICKER_LOCALES));
@@ -126,14 +126,14 @@ const buildDateLocales = () => {
 			const destFilename = path.resolve(
 				MODULES_PATH,
 				localeCode,
-				"date",
-				"pickerLocale.json"
+				'date',
+				'pickerLocale.json'
 			);
 			mkdirp.sync(path.dirname(destFilename));
 			return writeFile(
 				destFilename,
 				JSON.stringify({ [localeCode]: PICKER_LOCALES[localeCode] })
-			).then(() => console.log("Wrote", destFilename));
+			).then(() => console.log('Wrote', destFilename));
 		})
 	);
 };
@@ -152,13 +152,13 @@ const buildTrnModules = () =>
 	);
 
 function main() {
-	console.log("Cleaning TRN modules directory");
+	console.log('Cleaning TRN modules directory');
 	child_process.execSync(`rm -rf ${MODULES_PATH}`);
 
-	console.log("Writing locale data modules for datepicker");
+	console.log('Writing locale data modules for datepicker');
 	buildDateLocales()
 		.then(() => {
-			console.log("Transpiling TRN source to JSON...");
+			console.log('Transpiling TRN source to JSON...');
 			return buildTrnModules().toPromise();
 		})
 		.then(
@@ -170,7 +170,7 @@ function main() {
 				);
 			},
 			err => {
-				console.error(chalk.red("TRN module build failed"));
+				console.error(chalk.red('TRN module build failed'));
 				console.error(chalk.red(err.toString()));
 				process.exit(1);
 			}
@@ -178,7 +178,7 @@ function main() {
 }
 
 module.exports = {
-	command: "trn",
-	description: "build the trn modules",
+	command: 'trn',
+	description: 'build the trn modules',
 	handler: main
 };

--- a/src/commands/buildCommands/trn.js
+++ b/src/commands/buildCommands/trn.js
@@ -1,17 +1,17 @@
-const { promisify } = require('util');
-const child_process = require('child_process');
-const fs = require('fs');
-const path = require('path');
-const chalk = require('chalk');
-const mkdirp = require('mkdirp');
+const { promisify } = require("util");
+const child_process = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const chalk = require("chalk");
+const mkdirp = require("mkdirp");
 
-const { paths, locales, package: packageConfig } = require('mwp-config');
+const { paths, locales, package: packageConfig } = require("mwp-config");
 const {
 	allLocalPoTrnsWithFallbacks$,
-	localTrns$,
-} = require('../txCommands/util');
+	localTrns$
+} = require("../txCommands/util");
 
-const MODULES_PATH = path.resolve(paths.repoRoot, 'src/trns/modules/');
+const MODULES_PATH = path.resolve(paths.repoRoot, "src/trns/modules/");
 
 const writeFile = promisify(fs.writeFile);
 
@@ -39,13 +39,13 @@ const writeTrnModules = messagesByLocale => ({ filename, msgids }) => {
 	// in dev, we want to build a single module containing all locales
 	if (
 		packageConfig.combineLanguages ||
-		process.env.NODE_ENV !== 'production'
+		process.env.NODE_ENV !== "production"
 	) {
 		// one trn file, all trns
 		const relPath = path.relative(paths.srcPath, filename);
 		const destFilename = path.resolve(
 			MODULES_PATH,
-			'combined',
+			"combined",
 			`${relPath}.json`
 		);
 		return writeTrnFile(destFilename, trns);
@@ -68,53 +68,53 @@ const writeTrnModules = messagesByLocale => ({ filename, msgids }) => {
 const componentTrnDefinitions$ = localTrns$.map(trnsFromFile => ({
 	filename: path.resolve(
 		paths.repoRoot,
-		trnsFromFile[0].file.replace(/\.jsx?$/, '')
+		trnsFromFile[0].file.replace(/\.jsx?$/, "")
 	),
-	msgids: trnsFromFile.map(({ id }) => id),
+	msgids: trnsFromFile.map(({ id }) => id)
 }));
 
 // Function for importing Flatpickr (fp) locale data for a particular 2-character
 // language code code - see https://flatpickr.js.org/localization/
 const fpLocale = lang => {
 	const langFile = require(require.resolve(`flatpickr/dist/l10n/${lang}`, {
-		paths: [paths.repoRoot],
+		paths: [paths.repoRoot]
 	}));
 	if (!langFile) {
 		console.error(
 			`Flatpickr locale data for language ${lang} cannot be returned`
 		);
 	}
-	return langFile;
+	return langFile.default[lang];
 };
 
 const PICKER_LOCALES = {
-	'en-US': undefined, // default
-	'en-AU': undefined, // default
-	'de-DE': fpLocale('de'),
-	es: fpLocale('es'),
-	'es-ES': fpLocale('es'),
-	'fr-FR': fpLocale('fr'),
-	'it-IT': fpLocale('it'),
-	'ja-JP': fpLocale('ja'),
-	'ko-KR': fpLocale('ko'),
-	'nl-NL': fpLocale('nl'),
-	'pt-BR': fpLocale('pt'),
-	'pl-PL': fpLocale('pl'),
-	'ru-RU': fpLocale('ru'),
-	'th-TH': fpLocale('th'),
-	'tr-TR': fpLocale('tr'),
+	"en-US": undefined, // default
+	"en-AU": undefined, // default
+	"de-DE": fpLocale("de"),
+	es: fpLocale("es"),
+	"es-ES": fpLocale("es"),
+	"fr-FR": fpLocale("fr"),
+	"it-IT": fpLocale("it"),
+	"ja-JP": fpLocale("ja"),
+	"ko-KR": fpLocale("ko"),
+	"nl-NL": fpLocale("nl"),
+	"pt-BR": fpLocale("pt"),
+	"pl-PL": fpLocale("pl"),
+	"ru-RU": fpLocale("ru"),
+	"th-TH": fpLocale("th"),
+	"tr-TR": fpLocale("tr")
 };
 const buildDateLocales = () => {
 	// in dev, we want to build a single module containing all locales
 	if (
 		packageConfig.combineLanguages ||
-		process.env.NODE_ENV !== 'production'
+		process.env.NODE_ENV !== "production"
 	) {
 		const destFilename = path.resolve(
 			MODULES_PATH,
-			'combined',
-			'date',
-			'pickerLocale.json'
+			"combined",
+			"date",
+			"pickerLocale.json"
 		);
 		mkdirp.sync(path.dirname(destFilename));
 		return writeFile(destFilename, JSON.stringify(PICKER_LOCALES));
@@ -126,14 +126,14 @@ const buildDateLocales = () => {
 			const destFilename = path.resolve(
 				MODULES_PATH,
 				localeCode,
-				'date',
-				'pickerLocale.json'
+				"date",
+				"pickerLocale.json"
 			);
 			mkdirp.sync(path.dirname(destFilename));
 			return writeFile(
 				destFilename,
 				JSON.stringify({ [localeCode]: PICKER_LOCALES[localeCode] })
-			).then(() => console.log('Wrote', destFilename));
+			).then(() => console.log("Wrote", destFilename));
 		})
 	);
 };
@@ -152,13 +152,13 @@ const buildTrnModules = () =>
 	);
 
 function main() {
-	console.log('Cleaning TRN modules directory');
+	console.log("Cleaning TRN modules directory");
 	child_process.execSync(`rm -rf ${MODULES_PATH}`);
 
-	console.log('Writing locale data modules for datepicker');
+	console.log("Writing locale data modules for datepicker");
 	buildDateLocales()
 		.then(() => {
-			console.log('Transpiling TRN source to JSON...');
+			console.log("Transpiling TRN source to JSON...");
 			return buildTrnModules().toPromise();
 		})
 		.then(
@@ -170,7 +170,7 @@ function main() {
 				);
 			},
 			err => {
-				console.error(chalk.red('TRN module build failed'));
+				console.error(chalk.red("TRN module build failed"));
 				console.error(chalk.red(err.toString()));
 				process.exit(1);
 			}
@@ -178,7 +178,7 @@ function main() {
 }
 
 module.exports = {
-	command: 'trn',
-	description: 'build the trn modules',
-	handler: main,
+	command: "trn",
+	description: "build the trn modules",
+	handler: main
 };

--- a/src/commands/buildCommands/trn.js
+++ b/src/commands/buildCommands/trn.js
@@ -8,7 +8,7 @@ const mkdirp = require('mkdirp');
 const { paths, locales, package: packageConfig } = require('mwp-config');
 const {
 	allLocalPoTrnsWithFallbacks$,
-	localTrns$
+	localTrns$,
 } = require('../txCommands/util');
 
 const MODULES_PATH = path.resolve(paths.repoRoot, 'src/trns/modules/');
@@ -70,14 +70,14 @@ const componentTrnDefinitions$ = localTrns$.map(trnsFromFile => ({
 		paths.repoRoot,
 		trnsFromFile[0].file.replace(/\.jsx?$/, '')
 	),
-	msgids: trnsFromFile.map(({ id }) => id)
+	msgids: trnsFromFile.map(({ id }) => id),
 }));
 
 // Function for importing Flatpickr (fp) locale data for a particular 2-character
 // language code code - see https://flatpickr.js.org/localization/
 const fpLocale = lang => {
 	const langFile = require(require.resolve(`flatpickr/dist/l10n/${lang}`, {
-		paths: [paths.repoRoot]
+		paths: [paths.repoRoot],
 	}));
 	if (!langFile) {
 		console.error(
@@ -102,7 +102,7 @@ const PICKER_LOCALES = {
 	'pl-PL': fpLocale('pl'),
 	'ru-RU': fpLocale('ru'),
 	'th-TH': fpLocale('th'),
-	'tr-TR': fpLocale('tr')
+	'tr-TR': fpLocale('tr'),
 };
 const buildDateLocales = () => {
 	// in dev, we want to build a single module containing all locales
@@ -180,5 +180,5 @@ function main() {
 module.exports = {
 	command: 'trn',
 	description: 'build the trn modules',
-	handler: main
+	handler: main,
 };


### PR DESCRIPTION
https://meetup.atlassian.net/browse/OS-90
Locale is being sent to the CalendarComponent like so
<img width="359" alt="screen shot 2019-02-14 at 2 42 33 pm" src="https://user-images.githubusercontent.com/10870371/52816547-82794700-306f-11e9-85e8-38104dfe1025.png">
According to the structure of the js object expected by CalendarComponent and Flatpickr's docs on using modules https://flatpickr.js.org/localization/#using-modules the json stored should look like the `default.${lang}` sub-object instead of the entire object.

<img width="707" alt="screen shot 2019-02-14 at 3 46 49 pm" src="https://user-images.githubusercontent.com/10870371/52816668-c3715b80-306f-11e9-9e5f-ffdb2064bed1.png">

It is now building the `trn` files as expected