### PR TITLE
Make tfx interface available through the default module export

### DIFF
--- a/src/commands/txCommands/pullAll.js
+++ b/src/commands/txCommands/pullAll.js
@@ -10,7 +10,7 @@ const getProjectResourcesList = () =>
 		// any changes in that resource. This should prevent any changes in
 		// feature branches from being overwritten by this resource
 		.then(slugs =>
-			slugs.sort(a => (a === txlib.ALL_TRANSLATIONS_RESOURCE ? -1 : 1))
+			slugs.sort(a => (a === txlib.tfx.ALL_TRANSLATIONS_RESOURCE ? -1 : 1))
 		);
 
 /**

--- a/src/commands/txCommands/pullAll.js
+++ b/src/commands/txCommands/pullAll.js
@@ -3,7 +3,7 @@ const txlib = require('./util');
 const gitHelpers = require('./util/gitHelpers');
 
 const getProjectResourcesList = () =>
-	txlib.resource
+	txlib.tfx.resource
 		.list()
 		// We want to sort the array of resources so that the ALL_TRANSLATIONS_RESOURCE is
 		// downloaded first, this will allow other resources to be applied on top of

--- a/src/commands/txCommands/util/index.js
+++ b/src/commands/txCommands/util/index.js
@@ -196,6 +196,7 @@ module.exports = {
 	getLocalTrnSourcePo,
 	pullResourceContent,
 	reduceUniques,
+	tfx,
 	updateTfxSrcMaster,
 	updateTfxSrcAllTranslations,
 	updateTfxCopyMaster,


### PR DESCRIPTION
A quick fix for the failing `pullAll` in the *-web pipelines: since the `tfx` functionality is now mainly accessed through `util/transifex`, I'm trying to minimize changes necessary by exposing the interface whole-sale through `util/index`. 