### PR TITLE
feature: write package trns to package-prefixed modules dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,20 @@
+# [10.1]
+
+*   **New feature** `mope trn` now writes package-specific TRNs to package-specific
+    TRN modules directory. Import package-specific TRNs in your code with
+    ```js
+    // /packages/my-cool-package/src/foo/ComponentWithTrns.jsx
+    import trns from 'trns/my-cool-package/foo/ComponentWithTrns';
+    ```
+
 # [10.0]
 
-* **BREAKING CHANGE** Babel 7 upgrade. mope commands updated:
-  *    `mope build browser` requires a `--babelConfig` option.
+*   **BREAKING CHANGE** Babel 7 upgrade. mope commands updated:
+    *   `mope build browser` requires a `--babelConfig` option.
         e.g. `mope build browser --babelConfig=./babel.config.js`
-  *    `mope build server` requires a `--babelConfig` option.
+    *   `mope build server` requires a `--babelConfig` option.
         e.g. `mope build server --babelConfig=./babel-loader.config.server.js`
-  *    `mope run` requires two new options, `--babelConfigBrowser`
+    *   `mope run` requires two new options, `--babelConfigBrowser`
         and `--babelConfigServer`
         e.g. `mope run --babelConfigBrowser=./babel.config.js --babelConfigServer=./babel-loader.config.server.js`
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 10.0.$(CI_BUILD_NUMBER)
+VERSION ?= 10.1.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/src/commands/buildCommands/configs/rules.js
+++ b/src/commands/buildCommands/configs/rules.js
@@ -54,7 +54,11 @@ module.exports = (babelConfig, buildType) => {
 		js: jsRules,
 		scssModule: {
 			test: /\.module\.scss$/,
-			include: [paths.srcPath, paths.localPackages],
+			include: [
+				paths.srcPath,
+				paths.localPackages,
+				/\/node_modules\/@meetup\//,
+			],
 			use: [
 				'isomorphic-style-loader',
 				{


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/166855878

Feature update to correctly transpile TRN source content into TRN modules inside `src/trns/modules/...`. No consume changes required, although all packages importing TRNs will need to use the import path of `'trns/my-package-name/path/to/source';`

This is a blocker for https://github.com/meetup/mup-web/pull/6013