### PR TITLE
Omit story and test files from trn src glob

### DIFF
--- a/src/commands/txCommands/util/index.js
+++ b/src/commands/txCommands/util/index.js
@@ -12,7 +12,7 @@ const { logSuccess, logError } = require('./logger');
 const PO_DIR = path.resolve(paths.repoRoot, 'src/trns/po/');
 const TRN_SRC_GLOBS = [
 	'packages/**/src/**/*.jsx', // monorepo package TRN sources
-	'src/@(components|app)/**/*.jsx', // main app TRN sources
+	'src/@(components|app)/**/!(*.test|*.story).jsx', // main app TRN sources
 ];
 const TRN_SRC_GLOB = `${paths.repoRoot}/{${TRN_SRC_GLOBS.join()}}`;
 

--- a/src/commands/txCommands/util/poFormatters.js
+++ b/src/commands/txCommands/util/poFormatters.js
@@ -54,6 +54,7 @@ const poObjToPoString = poObj => {
 const msgDescriptorsToPoObj = messages =>
 	messages.reduce((acc, msg) => {
 		if (typeof msg.description !== 'object' || !msg.description.jira) {
+			console.log(msg.file);
 			throw new Error('Trn content missing jira story reference', msg);
 		}
 


### PR DESCRIPTION
With the latest mwp-cli, we found errors in `pro-web` where a trn was being defined in a test file so the entire build error'd. 

To avoid this, let's go back to omit-ting story and test files from the trn src glob.

Reference, removed here: https://github.com/meetup/mwp-cli/commit/010d869c55041ba65da274fdcbb93d5a459abb05#diff-b7ed5127b5fcf4b7bfb5d049d728fc07L66