### PR TITLE
Remove `jira` validation & stringify description object key-values

### DIFF
--- a/src/commands/txCommands/util/__snapshots__/poFormatters.test.js.snap
+++ b/src/commands/txCommands/util/__snapshots__/poFormatters.test.js.snap
@@ -6,7 +6,7 @@ Object {
     "comments": Object {
       "extracted": "foo description text",
       "reference": "/src/path/to/source/file.jsx:10:11",
-      "translator": "WP-1234",
+      "translator": "jira: WP-1234",
     },
     "msgid": "msg.mock.id",
     "msgstr": Array [

--- a/src/commands/txCommands/util/poFormatters.js
+++ b/src/commands/txCommands/util/poFormatters.js
@@ -51,19 +51,33 @@ const poObjToPoString = poObj => {
 };
 
 // Array<MessageDescriptor> => Po
+// https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html
+/**
+ * special handling of description object
+ * - 'text' will be assigned to `comments.extracted`.
+ * - all other key/values will be converted to a 'key: value; ...' string and
+ *   assigned to `comments.translator`, e.g.
+ *
+ * description = {
+ * 	text: 'info for translator',
+ *  jira: 'asdfas',
+ *  pivotal: 'asdfasd'
+ * }
+ *
+ * yields: 'jira: asdfas; pivotal: asdfasdf'
+ */
 const msgDescriptorsToPoObj = messages =>
 	messages.reduce((acc, msg) => {
-		if (typeof msg.description !== 'object' || !msg.description.jira) {
-			console.log(msg.file);
-			throw new Error('Trn content missing jira story reference', msg);
-		}
+		const { text, ...otherDesc } = msg.description;
 
 		acc[msg.id] = {
 			msgid: msg.id,
 			msgstr: [msg.defaultMessage],
 			comments: {
-				extracted: msg.description.text,
-				translator: msg.description.jira,
+				extracted: text,
+				translator: Object.keys(otherDesc)
+					.map(k => `${k}: ${otherDesc[k]}`)
+					.join('; '),
 				reference: `${msg.file}:${msg.start.line}:${msg.start.column}`,
 			},
 		};

--- a/src/commands/txCommands/util/poFormatters.js
+++ b/src/commands/txCommands/util/poFormatters.js
@@ -50,21 +50,34 @@ const poObjToPoString = poObj => {
 	return `${gettextParser.po.compile(headerWrapped).toString()}\n`;
 };
 
-// Array<MessageDescriptor> => Po
-// https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html
 /**
- * special handling of description object
- * - 'text' will be assigned to `comments.extracted`.
- * - all other key/values will be converted to a 'key: value; ...' string and
- *   assigned to `comments.translator`, e.g.
+ * Convert array of message descriptors into a PO object
+ *   Array<MessageDescriptor> => Po
  *
+ * https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html
+ *
+ * This transform includes special handling of the `description` parameter
+ * - `description.text` will be assigned to `comments.extracted`.
+ * - all other `description` key/values will be converted to a 'key: value; ...'
+ *   string and assigned to `comments.translator`, e.g.
+ *
+ * ```
  * description = {
  * 	text: 'info for translator',
- *  jira: 'asdfas',
- *  pivotal: 'asdfasd'
+ *  jira: 'whatever',
+ *  pivotal: 'something else'
  * }
+ * ```
  *
- * yields: 'jira: asdfas; pivotal: asdfasdf'
+ * yields:
+ *
+ * ```
+ * comments: {
+ *  text: 'info for translator',
+ *  translator: 'jira: whatever; pivotal: asdfasdf'
+ *  ...
+ * }
+ * ```
  */
 const msgDescriptorsToPoObj = messages =>
 	messages.reduce((acc, msg) => {


### PR DESCRIPTION
Engineers can now avoid defining a `jira` property in the TRN message descriptors. Also, other `description` keys will be more clearly labeled in the PO objects/files