### PR TITLE
Add home-relative babel-loader cacheDirectory that can be re-used in CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# [13.1]
+
+-   **New feature** The babel-loader config now specifies a cache directory that
+    can be used to speed up subsequent builds: `~/.cache/babel`. To take advantage
+    of this in CI, make sure you add this directory to the CI cache, e.g. in Travis:
+
+    ```yaml
+    cache:
+        - $HOME/.cache/babel
+    ```
+
 # [13.0]
 
 -   **BREAKING CHANGE** Deprecate `mope deploy`, now we are using aws native command for deploy app.
@@ -5,11 +16,11 @@
 
 # [12.1]
 
-- **Fixed** postcss-loader will no longer emit warnings for 'undefined' properties
-  implicitly loaded in global scope from `@meetup/swarm-constants`. Note that there
-  is a new peer dependency on that package, which is technically a breaking change,
-  but all consumers are already using that package, so it won't require anything
-  other than a dependency version bump.
+-   **Fixed** postcss-loader will no longer emit warnings for 'undefined' properties
+    implicitly loaded in global scope from `@meetup/swarm-constants`. Note that there
+    is a new peer dependency on that package, which is technically a breaking change,
+    but all consumers are already using that package, so it won't require anything
+    other than a dependency version bump.
 
 # [12.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # [13.1]
 
--   **New feature** The babel-loader config now specifies a cache directory that
-    can be used to speed up subsequent builds: `~/.cache/babel`. To take advantage
-    of this in CI, make sure you add this directory to the CI cache, e.g. in Travis:
+-   **New feature** The babel-loader config used by `mope bundle` now specifies
+    a cache directory that can be used to speed up subsequent builds: `~/.cache/babel`.
+    To take advantage of this in CI, make sure you add this directory to the CI
+    cache, e.g. in Travis:
 
     ```yaml
     cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # [13.1]
 
 -   **New feature** The babel-loader config used by `mope bundle` now specifies
-    a cache directory that can be used to speed up subsequent builds: `~/.cache/babel`.
-    To take advantage of this in CI, make sure you add this directory to the CI
-    cache, e.g. in Travis:
+    a cache directory that can be used to speed up subsequent builds:
+    `~/.cache/babel-loader`. To take advantage of this in CI, make sure you add
+    this directory to the CI cache, e.g. in Travis:
 
     ```yaml
     cache:
-        - $HOME/.cache/babel
+        - $HOME/.cache/babel-loader
     ```
 
 # [13.0]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 13.0.$(CI_BUILD_NUMBER)
+VERSION ?= 13.1.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/src/commands/buildCommands/configs/rules.js
+++ b/src/commands/buildCommands/configs/rules.js
@@ -1,6 +1,4 @@
-const os = require('os');
 const path = require('path');
-const mkdirp = require('mkdirp');
 const { env, paths } = require('mwp-config');
 const postCssLoaderConfig = require('./postCssLoaderConfig.js');
 
@@ -14,25 +12,17 @@ const postCssLoaderConfig = require('./postCssLoaderConfig.js');
  *
  * @param buildtype string one of [browser|server]
  */
-
-// custom cache directory that can be saved between runs of CI build
-const cacheDirectory = mkdirp.sync(path.resolve(os.homedir(), '.cache/babel/'));
-
 module.exports = (babelConfig, buildType) => {
 	const browserJSRules = {
 		// standard ES5 transpile through Babel
 		test: /\.(ts|js)x?$/,
-		include: [
-			paths.src.browser.app,
-			paths.packages.webComponents.src,
-			paths.packages.mupwebPackages.lib,
-		], // need localPackages here for source maps to work
+		include: [paths.src.browser.app, paths.packages.webComponents.src, paths.packages.mupwebPackages.lib],// need localPackages here for source maps to work
 		exclude: paths.src.asset,
 		use: [
 			{
 				loader: 'babel-loader',
 				options: {
-					cacheDirectory,
+					cacheDirectory: true,
 					plugins: env.properties.isDev
 						? babelConfig.plugins.concat(['react-hot-loader/babel'])
 						: babelConfig.plugins,
@@ -50,7 +40,7 @@ module.exports = (babelConfig, buildType) => {
 			{
 				loader: 'babel-loader',
 				options: {
-					cacheDirectory,
+					cacheDirectory: true,
 					plugins: babelConfig.plugins,
 					presets: babelConfig.presets,
 				},

--- a/src/commands/buildCommands/configs/rules.js
+++ b/src/commands/buildCommands/configs/rules.js
@@ -1,4 +1,6 @@
+const os = require('os');
 const path = require('path');
+const mkdirp = require('mkdirp');
 const { env, paths } = require('mwp-config');
 const postCssLoaderConfig = require('./postCssLoaderConfig.js');
 
@@ -12,17 +14,25 @@ const postCssLoaderConfig = require('./postCssLoaderConfig.js');
  *
  * @param buildtype string one of [browser|server]
  */
+
+// custom cache directory that can be saved between runs of CI build
+const cacheDirectory = mkdirp.sync(path.resolve(os.homedir(), '.cache/babel/'));
+
 module.exports = (babelConfig, buildType) => {
 	const browserJSRules = {
 		// standard ES5 transpile through Babel
 		test: /\.(ts|js)x?$/,
-		include: [paths.src.browser.app, paths.packages.webComponents.src, paths.packages.mupwebPackages.lib],// need localPackages here for source maps to work
+		include: [
+			paths.src.browser.app,
+			paths.packages.webComponents.src,
+			paths.packages.mupwebPackages.lib,
+		], // need localPackages here for source maps to work
 		exclude: paths.src.asset,
 		use: [
 			{
 				loader: 'babel-loader',
 				options: {
-					cacheDirectory: true,
+					cacheDirectory,
 					plugins: env.properties.isDev
 						? babelConfig.plugins.concat(['react-hot-loader/babel'])
 						: babelConfig.plugins,
@@ -40,7 +50,7 @@ module.exports = (babelConfig, buildType) => {
 			{
 				loader: 'babel-loader',
 				options: {
-					cacheDirectory: true,
+					cacheDirectory,
 					plugins: babelConfig.plugins,
 					presets: babelConfig.presets,
 				},

--- a/src/commands/bundleCommands/configs/rules.js
+++ b/src/commands/bundleCommands/configs/rules.js
@@ -19,7 +19,6 @@ const assetPath = path.resolve(legacySrcPath, 'assets');
  */
 // custom cache directory that can be saved between runs of CI build
 const cacheDirectory = path.resolve(os.homedir(), '.cache/babel-loader/');
-console.log('cache dir', cacheDirectory);
 
 module.exports = (babelConfig, buildType) => {
 	const browserJSRules = {

--- a/src/commands/bundleCommands/configs/rules.js
+++ b/src/commands/bundleCommands/configs/rules.js
@@ -1,3 +1,4 @@
+const os = require('os');
 const path = require('path');
 const { env, paths } = require('mwp-config');
 const postCssLoaderConfig = require('./postCssLoaderConfig.js');
@@ -16,6 +17,10 @@ const assetPath = path.resolve(legacySrcPath, 'assets');
  *
  * @param buildtype string one of [browser|server]
  */
+// custom cache directory that can be saved between runs of CI build
+const cacheDirectory = path.resolve(os.homedir(), '.cache/babel-loader/');
+console.log('cache dir', cacheDirectory);
+
 module.exports = (babelConfig, buildType) => {
 	const browserJSRules = {
 		// standard ES5 transpile through Babel
@@ -31,7 +36,7 @@ module.exports = (babelConfig, buildType) => {
 			{
 				loader: 'babel-loader',
 				options: {
-					cacheDirectory: true,
+					cacheDirectory,
 					plugins: env.properties.isDev
 						? babelConfig.plugins.concat(['react-hot-loader/babel'])
 						: babelConfig.plugins,
@@ -49,7 +54,7 @@ module.exports = (babelConfig, buildType) => {
 			{
 				loader: 'babel-loader',
 				options: {
-					cacheDirectory: true,
+					cacheDirectory,
 					plugins: babelConfig.plugins,
 					presets: babelConfig.presets,
 				},


### PR DESCRIPTION
Using this cache directory appears to cut the build time in half (for `mope bundle ...`), from about 2 minutes to about 1 minute. It's sort of a small, but very easy optimization that should also help build speed in dev even when clearing the `node_modules` directory