### PR TITLE
Sort the PO keys before writing PO file

### DIFF
--- a/src/commands/txCommands/util/__snapshots__/poFormatters.test.js.snap
+++ b/src/commands/txCommands/util/__snapshots__/poFormatters.test.js.snap
@@ -16,26 +16,6 @@ Object {
 }
 `;
 
-exports[`poObjToPoString takes trn content, returns po file: 
-"msgid \\"\\"
-msgstr \\"Content-Type: text/plain; charset=utf-8\\\\n\\"
-
-# WP-1234
-#: packages/mupweb-legacy/src/path/to/component.trns.jsx:4:45
-msgid \\"mockMessage.id\\"
-msgstr \\"mock translated copy\\"
-"
- 1`] = `
-"msgid \\"\\"
-msgstr \\"Content-Type: text/plain; charset=utf-8\\\\n\\"
-
-# WP-1234
-#: src/path/to/component.trns.jsx:4:45
-msgid \\"mockMessage.id\\"
-msgstr \\"mock translated copy\\"
-"
-`;
-
 exports[`poStringToPoObj parses PO-formatted file content into a plain JS object map 1`] = `
 Object {
   "mockMessage.id": Object {

--- a/src/commands/txCommands/util/__snapshots__/poFormatters.test.js.snap
+++ b/src/commands/txCommands/util/__snapshots__/poFormatters.test.js.snap
@@ -16,6 +16,31 @@ Object {
 }
 `;
 
+exports[`poObjToPoString takes trn content, returns po file: 
+"msgid \\"\\"
+msgstr \\"Content-Type: text/plain; charset=utf-8\\\\n\\"
+
+# WP-1234
+#: packages/mupweb-legacy/src/path/to/component.trns.jsx:4:45
+msgid \\"mockMessage.id\\"
+msgstr \\"mock translated copy\\"
+"
+ 1`] = `
+"msgid \\"\\"
+msgstr \\"Content-Type: text/plain; charset=utf-8\\\\n\\"
+
+# WP-12345
+#: src/path/to/component.trns.jsx:5:45
+msgid \\"aMockMessage.id2\\"
+msgstr \\"mock translated copy\\"
+
+# WP-1234
+#: src/path/to/component.trns.jsx:4:45
+msgid \\"mockMessage.id\\"
+msgstr \\"mock translated copy\\"
+"
+`;
+
 exports[`poStringToPoObj parses PO-formatted file content into a plain JS object map 1`] = `
 Object {
   "mockMessage.id": Object {

--- a/src/commands/txCommands/util/poFormatters.js
+++ b/src/commands/txCommands/util/poFormatters.js
@@ -38,13 +38,17 @@ const poStringToPoObj = fileContent => {
 
 // take a set of PoTrn and compile a po file contents string
 const poObjToPoString = poObj => {
+	// sort the object to help make PO file output deterministic
+	const sortedPoObj = Object.keys(poObj)
+		.sort()
+		.reduce((acc, key) => ({ ...acc, [key]: poObj[key] }), {});
 	const headerWrapped = {
 		charset: 'utf-8',
 		headers: {
 			'content-type': 'text/plain; charset=utf-8',
 		},
 		translations: {
-			'': poObj,
+			'': sortedPoObj,
 		},
 	};
 	return `${gettextParser.po.compile(headerWrapped).toString()}\n`;

--- a/src/commands/txCommands/util/poFormatters.test.js
+++ b/src/commands/txCommands/util/poFormatters.test.js
@@ -20,6 +20,14 @@ const PO_OBJ = {
 		msgid: 'mockMessage.id',
 		msgstr: ['mock translated copy'],
 	},
+	'aMockMessage.id2': {
+		comments: {
+			reference: 'src/path/to/component.trns.jsx:5:45',
+			translator: 'WP-12345',
+		},
+		msgid: 'aMockMessage.id2',
+		msgstr: ['mock translated copy'],
+	},
 };
 
 describe('poStringToPoObj', () => {
@@ -78,21 +86,22 @@ test('msgDescriptorsToPoObj', () => {
 test('poStringToPoResource', () => {
 	expect(poStringToPoResource('WP_slug_example', PO_FILE_CONTENT))
 		.toMatchInlineSnapshot(`
-Object {
-  "content": "# WP-1234
-#: packages/mupweb-legacy/src/path/to/component.trns.jsx:4:45
-msgid \\"mockMessage.id\\"
-msgstr \\"mock translated copy\\"",
-  "i18n_type": "PO",
-  "name": "WP_slug_example",
-  "slug": "WP_slug_example",
-}
-`);
+		Object {
+		  "content": "# WP-1234
+		#: packages/mupweb-legacy/src/path/to/component.trns.jsx:4:45
+		msgid \\"mockMessage.id\\"
+		msgstr \\"mock translated copy\\"",
+		  "i18n_type": "PO",
+		  "name": "WP_slug_example",
+		  "slug": "WP_slug_example",
+		}
+	`);
 });
 test('poObjToMsgObj', () => {
 	expect(poObjToMsgObj(PO_OBJ)).toMatchInlineSnapshot(`
-Object {
-  "mockMessage.id": "mock translated copy",
-}
-`);
+		Object {
+		  "aMockMessage.id2": "mock translated copy",
+		  "mockMessage.id": "mock translated copy",
+		}
+	`);
 });


### PR DESCRIPTION
for https://www.pivotaltracker.com/story/show/170032992, followup from Slack mention of redundant/messy automatedTRN PRs: https://meetuphq.slack.com/archives/C3MD0EV7V/p1573500476009700

This will make the PO file output more deterministic (sorted by `msgid`) so that we can avoid redundant automated TRN builds and see specific changes more clearly.