### PR TITLE
Fix MupWeb travis build crash on timeout

### DIFF
--- a/src/commands/bundleCommands/pull.js
+++ b/src/commands/bundleCommands/pull.js
@@ -33,7 +33,7 @@ module.exports = {
 				describe: 'The time to wait between bundle progress checks',
 			},
 			timeout: {
-				default: 30 * 60 * 1000,
+				default: 60 * 60 * 1000,
 				describe: 'Time to wait for bundles to become available for pull',
 			},
 			tags: {


### PR DESCRIPTION
Fix MupWeb travis build crash on timeouts running "mope bundle pull --s3Bucket=mwp-mup-web-prod-app-build" with mwp-cli/src/commands/bundleCommands/pull.js:61	throw new Error(`Timeout - ${Math.floor(timeout / 1000)}sec`);