### PR TITLE
ci: retry npm publish step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,11 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Release ${{ github.run_number }}-beta
         if: github.event_name == 'pull_request'
-        run: |
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 2
+          max_attempts: 3
+          command: |
           export GIT_TAG=$(make version)-beta
           export NPM_TAG=beta
           git config --global user.email "revenue-guardians@meetup.com"
@@ -48,7 +52,11 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Release ${{ github.run_number }}
         if: github.ref == 'refs/heads/master'
-        run: |
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 2
+          max_attempts: 3
+          command: |
           export GIT_TAG=$(make version)
           export NPM_TAG=latest
           git config --global user.email "revenue-guardians@meetup.com"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,12 @@ jobs:
           timeout_minutes: 2
           max_attempts: 3
           command: |
-          export GIT_TAG=$(make version)-beta
-          export NPM_TAG=beta
-          git config --global user.email "revenue-guardians@meetup.com"
-          git config --global user.name "meetcvs"
-          npm version $GIT_TAG -m "Version $GIT_TAG built by Github action"
-          npm publish --tag $NPM_TAG
+            export GIT_TAG=$(make version)-beta
+            export NPM_TAG=beta
+            git config --global user.email "revenue-guardians@meetup.com"
+            git config --global user.name "meetcvs"
+            npm version $GIT_TAG -m "Version $GIT_TAG built by Github action"
+            npm publish --tag $NPM_TAG
         env:
           CI_BUILD_NUMBER: ${{ github.run_number }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -57,12 +57,12 @@ jobs:
           timeout_minutes: 2
           max_attempts: 3
           command: |
-          export GIT_TAG=$(make version)
-          export NPM_TAG=latest
-          git config --global user.email "revenue-guardians@meetup.com"
-          git config --global user.name "meetcvs"
-          npm version $GIT_TAG -m "Version $GIT_TAG built by Github action"
-          npm publish --tag $NPM_TAG
+            export GIT_TAG=$(make version)
+            export NPM_TAG=latest
+            git config --global user.email "revenue-guardians@meetup.com"
+            git config --global user.name "meetcvs"
+            npm version $GIT_TAG -m "Version $GIT_TAG built by Github action"
+            npm publish --tag $NPM_TAG
         env:
           CI_BUILD_NUMBER: ${{ github.run_number }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Currently, the npm package publishing often failed, thus adding a retry action to save some manual clicks.