### PR TITLE
Revert "chore(deps): bump postcss-css-variables from 0.13.0 to 0.18.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "mkdirp": "0.5.1",
     "node-sass": "4.13.1",
     "postcss": "8.3.0",
-    "postcss-css-variables": "0.18.0",
+    "postcss-css-variables": "0.13.0",
     "postcss-loader": "3.0.0",
     "postcss-preset-env": "6.7.0",
     "raw-loader": "0.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7587,13 +7587,13 @@ postcss-convert-values@^4.0.1:
     postcss "^7.0.0"
     postcss-value-parser "^3.0.0"
 
-postcss-css-variables@0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/postcss-css-variables/-/postcss-css-variables-0.18.0.tgz#d97b6da19e86245eb817006e11117382f997bb93"
+postcss-css-variables@0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/postcss-css-variables/-/postcss-css-variables-0.13.0.tgz#42adcec7e963020801b106b6452d6a3e9c24bc87"
   dependencies:
-    balanced-match "^1.0.0"
     escape-string-regexp "^1.0.3"
     extend "^3.0.1"
+    postcss "^6.0.8"
 
 postcss-custom-media@^7.0.8:
   version "7.0.8"


### PR DESCRIPTION
Reverts meetup/mwp-cli#446

---

```
ModuleBuildError: Module build failed (from ./node_modules/postcss-loader/src/index.js):
Error: [object Object] is not a PostCSS plugin
    at Processor.normalize (/home/travis/build/meetup/mup-web/node_modules/postcss-loader/node_modules/postcss/lib/processor.js:168:15)
    at new Processor (/home/travis/build/meetup/mup-web/node_modules/postcss-loader/node_modules/postcss/lib/processor.js:52:25)
    at postcss (/home/travis/build/meetup/mup-web/node_modules/postcss-loader/node_modules/postcss/lib/postcss.js:55:10)
    at Promise.resolve.then.then (/home/travis/build/meetup/mup-web/node_modules/postcss-loader/src/index.js:140:12)
```

caused [container build issue](https://travis-ci.com/github/meetup/mup-web/jobs/511790219)